### PR TITLE
Add Toggleable Debug Console

### DIFF
--- a/ZeldaOracle/Game/Common/Util/NativeMethods.cs
+++ b/ZeldaOracle/Game/Common/Util/NativeMethods.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ZeldaOracle.Common.Util {
+	public static class NativeMethods {
+
+		/**<summary>The standard output device. Initially, this is the active console screen buffer, CONOUT$.</summary>*/
+		public const uint StdOutputHandle = 0xFFFFFFF5;
+
+		/**<summary>Allocates a new console for the calling process.</summary>*/
+		[DllImport("kernel32.dll")]
+		public static extern bool AllocConsole();
+
+		/**<summary>Detaches the calling process from its console.</summary>*/
+		[DllImport("kernel32.dll")]
+		public static extern bool FreeConsole();
+
+		/**<summary>Retrieves a handle to the specified standard device
+		 * (standard input, standard output, or standard error).</summary>*/
+		[DllImport("kernel32.dll")]
+		public static extern IntPtr GetStdHandle(uint nStdHandle);
+
+		/**<summary>Sets the handle for the specified standard device
+		 * (standard input, standard output, or standard error).</summary>*/
+		[DllImport("kernel32.dll")]
+		public static extern void SetStdHandle(uint nStdHandle, IntPtr hHandle);
+
+		/**<summary>Sets the title for the current console window.</summary>*/
+		[DllImport("kernel32.dll")]
+		public static extern bool SetConsoleTitle(string lpConsoleTitle);
+	}
+}

--- a/ZeldaOracle/Game/Game/Debug/GameDebug.cs
+++ b/ZeldaOracle/Game/Game/Debug/GameDebug.cs
@@ -77,13 +77,16 @@ namespace ZeldaOracle.Game.Debug {
 		public static void UpdateRoomDebugKeys() {
 			bool ctrl = (Keyboard.IsKeyDown(Keys.LControl) ||
 				Keyboard.IsKeyDown(Keys.RControl));
-			
+
 			// CTRL+Q: Quit the game
 			if (ctrl && Keyboard.IsKeyPressed(Keys.Q))
 				GameManager.Exit();
 			// CTRL+R: Restart the game.
 			if (ctrl && Keyboard.IsKeyPressed(Keys.R))
 				GameManager.Restart();
+			// CTRL+R: Toggle console window.
+			if (ctrl && Keyboard.IsKeyPressed(Keys.T))
+				GameManager.IsConsoleOpen = !GameManager.IsConsoleOpen;
 			// F5: Pause gameplay.
 			if (!ctrl && Keyboard.IsKeyPressed(Keys.F5))
 				GameManager.IsGamePaused = !GameManager.IsGamePaused;
@@ -355,7 +358,7 @@ namespace ZeldaOracle.Game.Debug {
 		}
 
 		
-		// Load a level from an java level file.
+		// Load a level from a Java level file.
 		public static Level LoadJavaLevel(string filename) {
             BinaryReader bin = new BinaryReader(File.OpenRead(filename));
 			int width	= bin.ReadByte();
@@ -376,7 +379,7 @@ namespace ZeldaOracle.Game.Debug {
 			return level;
 		}
 		
-		// Load a single room from an java level file.
+		// Load a single room from an Java level file.
 		public static Room LoadJavaRoom(BinaryReader bin, Level level, int locX, int locY) {
 			byte width		= bin.ReadByte();
 			byte height		= bin.ReadByte();

--- a/ZeldaOracle/Game/Game/Entities/Players/Player.cs
+++ b/ZeldaOracle/Game/Game/Entities/Players/Player.cs
@@ -107,8 +107,8 @@ namespace ZeldaOracle.Game.Entities.Players {
 
 			// Unit properties.
 			centerOffset			= new Point2I(0, -5);
+			MaxHealth               = 4 * 3;
 			Health					= 4 * 3;
-			MaxHealth				= 4 * 3;
 			swimmingSkills			= PlayerSwimmingSkills.CannotSwim;
 			tunic					= PlayerTunics.GreenTunic;
 			moveAnimation			= GameData.ANIM_PLAYER_DEFAULT;

--- a/ZeldaOracle/Game/Game/Main/GameBase.cs
+++ b/ZeldaOracle/Game/Game/Main/GameBase.cs
@@ -105,7 +105,8 @@ namespace ZeldaOracle.Game.Main {
 			this.graphics.PreferredBackBufferHeight	= windowSize.Y;
 			
 			Form.Icon = new Icon("Game.ico");
-			Form.MinimumSize = new System.Drawing.Size(32, 32);
+			Form.MinimumSize = new Size(32, 32);
+			Form.Shown += OnWindowShown;
 		}
 
 		/// <summary>
@@ -115,14 +116,14 @@ namespace ZeldaOracle.Game.Main {
 		/// and initialize them as well.
 		/// </summary>
 		protected override void Initialize() {
+			game = new GameManager(launchParameters, this);
+
 			Console.WriteLine("Begin Initialize");
 
 			Console.WriteLine("Initializing Input");
 			Keyboard.Initialize();
 			Mouse.Initialize();
 			GamePad.Initialize();
-
-			game = new GameManager(launchParameters);
 			
 			base.Initialize();
 
@@ -133,7 +134,7 @@ namespace ZeldaOracle.Game.Main {
 			}
 
 			// Create and initialize the game.
-			game.Initialize(this);
+			game.Initialize();
 
 			Window.ClientSizeChanged += OnClientSizeChanged;
 
@@ -161,7 +162,7 @@ namespace ZeldaOracle.Game.Main {
 				AudioSystem.Initialize();
 				Resources.Initialize(Content, GraphicsDevice);
 
-				game.LoadContent(Content, this);
+				game.LoadContent(Content);
 
 				base.LoadContent();
 
@@ -179,7 +180,7 @@ namespace ZeldaOracle.Game.Main {
 		/// all content.
 		/// </summary>
 		protected override void UnloadContent() {
-			System.Console.WriteLine("Begin Unload Content");
+			Console.WriteLine("Begin Unload Content");
 
 			AudioSystem.Uninitialize();
 			//Resources.Uninitialize();
@@ -188,13 +189,19 @@ namespace ZeldaOracle.Game.Main {
 
 			base.UnloadContent();
 
-			System.Console.WriteLine("End Unload Content");
+			Console.WriteLine("End Unload Content");
 		}
 
 
 		//-----------------------------------------------------------------------------
 		// Events
 		//-----------------------------------------------------------------------------
+		
+		/**<summary>Called when the window is shown for the first time.
+		 * This event is primarily used to steal focus from the debug console on startup.</summary>*/
+		private void OnWindowShown(object sender, EventArgs e) {
+			Form.Activate();
+		}
 
 		/**<summary>Called when the window has been manually resized.</summary>*/
 		private void OnClientSizeChanged(object sender, EventArgs e) {
@@ -215,7 +222,7 @@ namespace ZeldaOracle.Game.Main {
 		//-----------------------------------------------------------------------------
 		// Updating
 		//-----------------------------------------------------------------------------
-		
+
 		/// <summary>
 		/// Allows the game to run logic such as updating the world,
 		/// checking for collisions, gathering input, and playing audio.

--- a/ZeldaOracle/Game/Zelda.csproj
+++ b/ZeldaOracle/Game/Zelda.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Common\Translation\LetterString.cs" />
     <Compile Include="Common\Translation\FormatCodes.cs" />
     <Compile Include="Common\Translation\WrappedLetterString.cs" />
+    <Compile Include="Common\Util\NativeMethods.cs" />
     <Compile Include="Game\Control\GameControl.cs" />
     <Compile Include="Game\Control\HUD.cs" />
     <Compile Include="Game\Control\Maps\DungeonMapFloor.cs" />

--- a/ZeldaOracle/GameEditor/Control/EditorControl.cs
+++ b/ZeldaOracle/GameEditor/Control/EditorControl.cs
@@ -70,6 +70,9 @@ namespace ZeldaEditor.Control {
 		// Settings
 		private bool				playAnimations;
 		private bool				eventMode;
+
+		// Debug
+		private bool                debugConsole;
 		
 		// Tools
 		private List<EditorTool>	tools;
@@ -383,7 +386,10 @@ namespace ZeldaEditor.Control {
 				WorldFile worldFile = new WorldFile();
 				worldFile.Save(worldPath, world, true);
 				string exePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "ZeldaOracle.exe");
-				Process.Start(exePath, "\"" + worldPath + "\"");
+				string arguments = "\"" + worldPath + "\"";
+				if (debugConsole)
+					arguments += " -console";
+				Process.Start(exePath, arguments);
 			}
 		}
 
@@ -400,7 +406,11 @@ namespace ZeldaEditor.Control {
 				WorldFile worldFile = new WorldFile();
 				worldFile.Save(worldPath, world, true);
 				string exePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "ZeldaOracle.exe");
-				Process.Start(exePath, "\"" + worldPath + "\" -test " + levelIndex + " " + roomCoord.X + " " + roomCoord.Y + " " + playerCoord.X + " " + playerCoord.Y);
+				string arguments = "\"" + worldPath + "\"";
+				arguments += " -test " + levelIndex + " " + roomCoord.X + " " + roomCoord.Y + " " + playerCoord.X + " " + playerCoord.Y;
+				if (debugConsole)
+					arguments += " -console";
+				Process.Start(exePath, arguments);
 				editorWindow.FinishTestWorldFromLocation();
 			}
 		}
@@ -1182,6 +1192,11 @@ namespace ZeldaEditor.Control {
 
 		public bool NoScriptWarnings {
 			get { return noScriptWarnings; }
+		}
+
+		public bool DebugConsole {
+			get { return debugConsole; }
+			set { debugConsole = value; }
 		}
 	}
 }

--- a/ZeldaOracle/GameEditor/EditorWindow.xaml
+++ b/ZeldaOracle/GameEditor/EditorWindow.xaml
@@ -96,6 +96,9 @@
                 <local:ImageMenuItem x:Name="menuItemTestWorld" Header="Test World" Source="Resources/Icons/RunGame.png" IsCheckable="True"  Command="cmd:EditorCommands.TestWorld"/>
                 <local:ImageMenuItem x:Name="menuItemTestLevelPlace" Header="Test World From Location" Source="Resources/Icons/RunGameAtLocation.png" Command="cmd:EditorCommands.TestWorldFromLocation"/>
             </MenuItem>
+            <MenuItem Header="_Debug">
+                <local:ImageMenuItem x:Name="menuItemDebugConsole" Header="Debug Console" Source="Resources/Icons/Console.png" Click="OnDebugConsole" IsCheckable="True" />
+            </MenuItem>
             <MenuItem Header="Dev Tools">
                 <MenuItem x:Name="menuItemRefactorProperties" Header="Refactor Properties..."/>
             </MenuItem>

--- a/ZeldaOracle/GameEditor/EditorWindow.xaml.cs
+++ b/ZeldaOracle/GameEditor/EditorWindow.xaml.cs
@@ -719,5 +719,9 @@ namespace ZeldaEditor {
 		public ZeldaPropertyGrid PropertyGrid {
 			get { return propertyGrid; }
 		}
+
+		private void OnDebugConsole(object sender, RoutedEventArgs e) {
+			editorControl.DebugConsole = menuItemDebugConsole.IsChecked;
+		}
 	}
 }

--- a/ZeldaOracle/GameEditor/Undo/ActionPlace.cs
+++ b/ZeldaOracle/GameEditor/Undo/ActionPlace.cs
@@ -38,7 +38,7 @@ namespace ZeldaEditor.Undo {
 		}
 
 		public void AddOverwrittenTile(Point2I point, TileDataInstance tile) {
-			if (!overwrittenTiles.ContainsKey(point))
+			if ((tile != null || placedTile != null) && !overwrittenTiles.ContainsKey(point))
 				overwrittenTiles.Add(point, tile);
 		}
 


### PR DESCRIPTION
Enabled the debug console in the Debug menu in the editor or toggle it
with Ctrl+T in-game.

Fixed player health starting at 1 instead of 12. It was due to Health
being set before MaxHealth.

Place action no longer pushes an action when no tiles were erased or
placed.