### PR TITLE
Regex Errors and Bugfixes

### DIFF
--- a/ZeldaOracle/ConscriptDesigner/MainWindow.xaml.cs
+++ b/ZeldaOracle/ConscriptDesigner/MainWindow.xaml.cs
@@ -61,6 +61,7 @@ namespace ConscriptDesigner {
 			Height = 260;
 			WindowStyle = WindowStyle.None;
 			ResizeMode = ResizeMode.NoResize;
+			dockPanel.Visibility = Visibility.Hidden;
 
 			Application.Current.Activated += OnApplicationActivated;
 

--- a/ZeldaOracle/ConscriptDesigner/Windows/FindReplaceWindow.xaml
+++ b/ZeldaOracle/ConscriptDesigner/Windows/FindReplaceWindow.xaml
@@ -43,7 +43,12 @@
             <TabItem Header="Replace" IsTabStop="False">
                 <StackPanel>
                     <TextBlock Margin="3">Text to Find:</TextBlock>
-                    <TextBox Margin="3" Name="textBoxReplaceFind" Text="{Binding ElementName=textBoxFind, Path=Text, Mode=TwoWay}" TextChanged="OnFindTextChanged"/>
+                    <TextBox Margin="3" Name="textBoxReplaceFind" TextChanged="OnFindTextChanged"
+                             Text="{Binding ElementName=textBoxFind, Path=Text}"
+                             Background="{Binding ElementName=textBoxFind, Path=Background}"
+                             Foreground="{Binding ElementName=textBoxFind, Path=Foreground}"
+                             CaretBrush="{Binding ElementName=textBoxFind, Path=CaretBrush}"
+                             ToolTip="{Binding ElementName=textBoxFind, Path=ToolTip}"/>
                     <TextBlock Margin="3" Text="Replace with:" />
                     <TextBox Margin="3" Name="textBoxReplace" />
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">

--- a/ZeldaOracle/GameEditor/EditorWindow.xaml
+++ b/ZeldaOracle/GameEditor/EditorWindow.xaml
@@ -12,7 +12,7 @@
         xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero"
         xmlns:System="clr-namespace:System;assembly=mscorlib"
         mc:Ignorable="d"
-        Title="Oracle Engine Editor" Width="1100" Height="640" SnapsToDevicePixels="True" UseLayoutRounding="True" Icon="Editor.ico" ResizeMode="CanResizeWithGrip" Loaded="OnWindowLoaded" PreviewKeyDown="OnPreviewKeyDown" SizeChanged="OnWindowSizeChanged" Closing="OnWindowClosing" PreviewMouseWheel="OnPreviewMouseWheel">
+        Title="Oracle Engine Editor" Width="1100" Height="640" SnapsToDevicePixels="True" UseLayoutRounding="True" Icon="Editor.ico" ResizeMode="CanResizeWithGrip" Loaded="OnWindowLoaded" PreviewKeyDown="OnPreviewKeyDown" SizeChanged="OnWindowSizeChanged" Closing="OnWindowClosing">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/ZeldaOracle/GameEditor/EditorWindow.xaml.cs
+++ b/ZeldaOracle/GameEditor/EditorWindow.xaml.cs
@@ -582,28 +582,7 @@ namespace ZeldaEditor {
 		private void OnRedoCommand(object sender, ExecutedRoutedEventArgs e) {
 			editorControl.Redo();
 		}
-
-
-
-
-		private void OnPreviewMouseWheel(object sender, MouseWheelEventArgs e) {
-			// Steal focus from the current control when scrolling over a scrollable area
-			if (treeViewWorld.IsMouseOverTreeView) {
-				treeViewWorld.FocusOnTreeView();
-			}
-			else if (propertyGrid.IsMouseOver) {
-				propertyGrid.Focus();
-			}
-		}
-
-		/*private void OnMouseWheel(object sender, MouseWheelEventArgs e) {
-			if (levelDisplay.IsMouseOver) {
-				levelDisplay.Focus();
-			}
-			else if (tileDisplay.IsMouseOver) {
-				tileDisplay.Focus();
-			}
-		}*/
+		
 
 		private void OnDebugConsole(object sender, RoutedEventArgs e) {
 			editorControl.DebugConsole = menuItemDebugConsole.IsChecked;

--- a/ZeldaOracle/GameEditor/PropertiesEditor/ZeldaPropertyGrid.cs
+++ b/ZeldaOracle/GameEditor/PropertiesEditor/ZeldaPropertyGrid.cs
@@ -115,9 +115,12 @@ namespace ZeldaEditor.PropertiesEditor {
 		}
 
 		public void CloseProperties() {
-			propertiesContainer.Clear();
-			UpdateContainerHelper();
-			editorControl.EditorWindow.UpdatePropertyPreview(propertyObject);
+			if (propertyObject != null) {
+				propertyObject = null;
+				propertiesContainer.Clear();
+				UpdateContainerHelper();
+				editorControl.EditorWindow.UpdatePropertyPreview(propertyObject);
+			}
 		}
 
 

--- a/ZeldaOracle/GameEditor/WinForms/MouseWheelMessageFilter.cs
+++ b/ZeldaOracle/GameEditor/WinForms/MouseWheelMessageFilter.cs
@@ -19,7 +19,10 @@ namespace ZeldaEditor.WinForms {
 
 		public bool PreFilterMessage(ref Message m) {
 			if (m.Msg == NativeMethods.WM_MOUSEWHEEL) {
-				if (element.IsMouseOver && !element.IsFocused) {
+				var focusElement = FocusManager.GetFocusedElement(element);
+				if (element.IsMouseOver && !element.IsFocused &&
+					focusElement != element && focusElement == null)
+				{
 					element.Focus();
 					HwndSource hwndSource = (HwndSource)HwndSource.FromVisual(element);
 					NativeMethods.SendMessage(hwndSource.Handle, m.Msg, m.WParam, m.LParam);


### PR DESCRIPTION
* The find textbox now shows up in red when there are regex errors.
* Fixed splash screen not displaying properly.
* Fixed editor bug where clicking on an empty tile would not change the
property object, thus clicking on the previously selected property
object would not show its properties.
* Fixed scrolling in the property grid with a combobox open would close
the combobox.