### PR TITLE
Add DynamicDepth to GraphicsComponent (Entity & Tiles)

### DIFF
--- a/ZeldaOracle/ConscriptDesigner/Themes/ConscriptHighlighting.xshd
+++ b/ZeldaOracle/ConscriptDesigner/Themes/ConscriptHighlighting.xshd
@@ -269,6 +269,7 @@
       <Word>CLONE</Word>
       <Word>SPRITESHEET</Word>
       <Word>PREVIEW</Word>
+      <Word>ENTITYDRAW</Word>
     </Keywords>
 
     <!--ZoneSR-->

--- a/ZeldaOracle/Game/Common/Scripts/CustomReaders/TileDataSR.cs
+++ b/ZeldaOracle/Game/Common/Scripts/CustomReaders/TileDataSR.cs
@@ -403,6 +403,12 @@ namespace ZeldaOracle.Common.Scripts.CustomReaders {
 				baseTileData.PreviewSprite = GetSpriteFromParams(parameters);
 			});
 			//=====================================================================================
+			AddCommand("ENTITYDRAW", (int) Modes.Tile,
+				"bool drawAsEntity",
+			delegate (CommandParam parameters) {
+				tileData.DrawAsEntity = parameters.GetBool(0);
+			});
+			//=====================================================================================
 			AddCommand("MODEL", (int) Modes.Root,
 				"string modeName",
 			delegate (CommandParam parameters) {

--- a/ZeldaOracle/Game/Game/Control/RoomControl.cs
+++ b/ZeldaOracle/Game/Game/Control/RoomControl.cs
@@ -591,6 +591,7 @@ namespace ZeldaOracle.Game.Control {
 
 				// Draw entities in reverse order (because newer entities are drawn below older ones).
 				roomGraphics.Clear();
+				tileManager.DrawEntityTiles(roomGraphics);
 				for (int i = entities.Count - 1; i >= 0; i--)
 					entities[i].Draw(roomGraphics);
 				roomGraphics.SortDepthLayer(DepthLayer.PlayerAndNPCs); // Sort dynamic depth layers.

--- a/ZeldaOracle/Game/Game/Control/TileManager.cs
+++ b/ZeldaOracle/Game/Game/Control/TileManager.cs
@@ -399,14 +399,14 @@ namespace ZeldaOracle.Game.Control {
 			}
 		}
 		
-		// Draw all tiles in the grid.
+		// Draw all tiles in the grid that draw with entities
 		public void DrawTiles(RoomGraphics g) {
 			for (int i = 0; i < layerCount; i++) {
 				for (int y = 0; y < GridHeight; y++) {
 					for (int x = 0; x < GridWidth; x++) {
 						Tile t = tiles[x, y, i];
 
-						if (t != null && IsTileAtGridLocation(t, x, y)) {
+						if (t != null && IsTileAtGridLocation(t, x, y) && !t.DrawAsEntity) {
 							t.Draw(g);
 
 							/*
@@ -438,6 +438,21 @@ namespace ZeldaOracle.Game.Control {
 			}
 		}
 
+
+		// Draw all tiles in the grid that do not draw with entities
+		public void DrawEntityTiles(RoomGraphics g) {
+			for (int i = 0; i < layerCount; i++) {
+				for (int y = 0; y < GridHeight; y++) {
+					for (int x = 0; x < GridWidth; x++) {
+						Tile t = tiles[x, y, i];
+
+						if (t != null && IsTileAtGridLocation(t, x, y) && t.DrawAsEntity)
+							t.Draw(g);
+					}
+				}
+			}
+		}
+
 		// Draw all tiles in the grid.
 		public void DrawTilesAbove(RoomGraphics g) {
 			for (int i = 0; i < layerCount; i++) {
@@ -445,9 +460,8 @@ namespace ZeldaOracle.Game.Control {
 					for (int x = 0; x < GridWidth; x++) {
 						Tile t = tiles[x, y, i];
 
-						if (t != null && IsTileAtGridLocation(t, x, y)) {
+						if (t != null && IsTileAtGridLocation(t, x, y))
 							t.DrawAbove(g);
-						}
 					}
 				}
 			}

--- a/ZeldaOracle/Game/Game/Entities/DepthLayer.cs
+++ b/ZeldaOracle/Game/Game/Entities/DepthLayer.cs
@@ -24,6 +24,12 @@ namespace ZeldaOracle.Game.Entities {
 		EffectSeed,
 		EffectGale,
 
+		// Used by crossing gate.
+		// Draws above player/monsters when player is above and vice-versa.
+		DynamicDepthBelowTileLayer2,
+		DynamicDepthBelowTileLayer3,
+		DynamicDepthBelowEntity,
+
 		Monsters,
 
 		EffectMonsterExplosion,
@@ -38,6 +44,11 @@ namespace ZeldaOracle.Game.Entities {
 
 		PlayerSwingItem,
 		PlayerAndNPCs,
+		// Used by crossing gate.
+		// Draws above player/monsters when player is above and vice-versa.
+		DynamicDepthAboveTileLayer2,
+		DynamicDepthAboveTileLayer3,
+		DynamicDepthAboveEntity,
 		RisingTile,
 		
 		InAirSeed,

--- a/ZeldaOracle/Game/Game/Entities/GraphicsComponent.cs
+++ b/ZeldaOracle/Game/Game/Entities/GraphicsComponent.cs
@@ -37,6 +37,12 @@ namespace ZeldaOracle.Game.Entities
 		private bool            unmapped;
 		private UnmappedSprite	unmappedSprite;
 		private Palette			unmappedPalette;
+		/// <summary>Draws above the player/monsters when
+		/// the player is above and vice-versa.</summary>
+		private bool			useDynamicDepth;
+		/// <summary>The y offset from the position of the tile to the origin.
+		/// Only needed for dynamic depth.</summary>
+		private int                 dynamicOriginY;
 
 
 		//-----------------------------------------------------------------------------
@@ -67,6 +73,8 @@ namespace ZeldaOracle.Game.Entities
 			this.unmapped				= false;
 			this.unmappedSprite			= null;
 			this.unmappedPalette		= null;
+			this.useDynamicDepth		= false;
+			this.dynamicOriginY			= 0;
 		}
 
 
@@ -180,6 +188,14 @@ namespace ZeldaOracle.Game.Entities
 		public void Draw(RoomGraphics g, DepthLayer layer) {
 			if (!isVisible)
 				return;
+
+			if (layer == CurrentDepthLayer && useDynamicDepth) {
+				float playerY = Entity.RoomControl.Player.Position.Y;
+				if (Math.Round(playerY) < Math.Round(Entity.Position.Y + dynamicOriginY))
+					depthLayer = DepthLayer.DynamicDepthAboveEntity;
+				else
+					depthLayer = DepthLayer.DynamicDepthBelowEntity;
+			}
 
 			// Draw the shadow.
 			if (isShadowVisible && entity.ZPosition >= 1 &&
@@ -376,6 +392,20 @@ namespace ZeldaOracle.Game.Entities
 				else
 					return colorDefinitions;
 			}
+		}
+
+		/// <summary>Gets if the t draws above the player/monsters
+		/// when the player is above and vice-versa.</summary>
+		public bool UseDynamicDepth {
+			get { return useDynamicDepth; }
+			set { useDynamicDepth = value; }
+		}
+
+		/// <summary>The y offset from the position of the tile to the origin.
+		/// Only needed for dynamic depth.</summary>
+		public int DynamicOriginY {
+			get { return dynamicOriginY; }
+			set { dynamicOriginY = value; }
 		}
 	}
 }

--- a/ZeldaOracle/Game/Game/Entities/Projectiles/PlayerProjectiles/PlayerBoomerang.cs
+++ b/ZeldaOracle/Game/Game/Entities/Projectiles/PlayerProjectiles/PlayerBoomerang.cs
@@ -105,7 +105,7 @@ namespace ZeldaOracle.Game.Entities.Projectiles.PlayerProjectiles {
 				collectible.SetPositionByCenter(Center);
 				collectible.ZPosition = zPosition;
 				float percent = i / (float) collectibles.Count;
-				collectible.Graphics.Draw(g, Graphics.CurrentDepthLayer);
+				collectible.Graphics.Draw(g);
 			}
 		}
 	}

--- a/ZeldaOracle/Game/Game/Entities/Projectiles/PlayerProjectiles/SwitchHookProjectile.cs
+++ b/ZeldaOracle/Game/Game/Entities/Projectiles/PlayerProjectiles/SwitchHookProjectile.cs
@@ -234,7 +234,7 @@ namespace ZeldaOracle.Game.Entities.Projectiles.PlayerProjectiles {
 				Vector2F pos = Center + Directions.ToVector(direction) * 4;
 				collectible.SetPositionByCenter(pos);
 				collectible.ZPosition = zPosition;
-				collectible.Graphics.Draw(g, Graphics.CurrentDepthLayer);
+				collectible.Graphics.Draw(g);
 			}
 		}
 

--- a/ZeldaOracle/Game/Game/Tiles/Custom/Minecart/TileCrossingGate.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Custom/Minecart/TileCrossingGate.cs
@@ -80,8 +80,10 @@ namespace ZeldaOracle.Game.Tiles {
 			dummySolidTile.SolidType		= TileSolidType.Solid;
 			dummySolidTile.IsSolid			= !IsRaised;
 			RoomControl.PlaceTile(dummySolidTile, trackLocation, Layer);
-		}
 
+			Graphics.UseDynamicDepth = true;
+			Graphics.DynamicOriginY = 2;
+		}
 
 		//-----------------------------------------------------------------------------
 		// Static Methods

--- a/ZeldaOracle/Game/Game/Tiles/Custom/Minecart/TileMinecartTrack.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Custom/Minecart/TileMinecartTrack.cs
@@ -142,6 +142,12 @@ namespace ZeldaOracle.Game.Tiles {
 					args.Color);
 			}*/
 			DrawTileDataIndex(g, args, (int) orientation);
+			if (args.Properties.GetBoolean("minecart", false)) {
+				if (orientation.HasDirection(Directions.Left) || orientation.HasDirection(Directions.Right))
+					g.DrawSprite(GameData.SPR_MINECART_HORIZONTAL, args.SpriteDrawSettings, args.Position, args.Color);
+				else
+					g.DrawSprite(GameData.SPR_MINECART_VERTICAL, args.SpriteDrawSettings, args.Position, args.Color);
+			}
 		}
 
 

--- a/ZeldaOracle/Game/Game/Tiles/Tile.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Tile.cs
@@ -884,6 +884,11 @@ namespace ZeldaOracle.Game.Tiles {
 			set { cancelBreakEffect = value; }
 		}
 
+		public bool DrawAsEntity {
+			get { return TileData.DrawAsEntity; }
+			set { TileData.DrawAsEntity = value; }
+		}
+
 		//-----------------------------------------------------------------------------
 		// Flag Properties
 		//-----------------------------------------------------------------------------

--- a/ZeldaOracle/Game/Game/Tiles/TileData.cs
+++ b/ZeldaOracle/Game/Game/Tiles/TileData.cs
@@ -88,6 +88,10 @@ namespace ZeldaOracle.Game.Tiles {
 			properties.Set("spawn_delay_after_poof", 31)
 				.SetDocumentation("Spawn Delay after Poof", "Spawning", "");
 
+			// Drawing
+			properties.Set("draw_as_entity", false)
+				.SetDocumentation("Draw as Entity", "", "", "Drawing", "", true, false);
+
 			// Events.
 			/*properties.Set("on_move", "")
 				.SetDocumentation("On Move", "script", "", "Events",
@@ -264,6 +268,11 @@ namespace ZeldaOracle.Game.Tiles {
 		public int HurtDamage {
 			get { return properties.GetInteger("hurt_damage", 0); }
 			set { properties.Set("hurt_damage", value); }
+		}
+
+		public bool DrawAsEntity {
+			get { return properties.GetBoolean("draw_as_entity", false); }
+			set { properties.Set("draw_as_entity", value); }
 		}
 	}
 }

--- a/ZeldaOracle/Game/Game/Tiles/TileDataInstance.cs
+++ b/ZeldaOracle/Game/Game/Tiles/TileDataInstance.cs
@@ -191,5 +191,10 @@ namespace ZeldaOracle.Game.Tiles {
 			get { return properties.GetFloat("conveyor_speed", 0.0f); }
 			set { properties.Set("conveyor_speed", value); }
 		}
+
+		public bool DrawAsEntity {
+			get { return TileData.DrawAsEntity; }
+			set { TileData.DrawAsEntity = value; }
+		}
 	}
 }

--- a/ZeldaOracle/Game/Game/Tiles/TileGraphicsComponent.cs
+++ b/ZeldaOracle/Game/Game/Tiles/TileGraphicsComponent.cs
@@ -23,6 +23,12 @@ namespace ZeldaOracle.Game.Tiles {
 		private Vector2F			absoluteDrawPosition;
 		private bool				useAbsoluteDrawPosition;
 		private ColorDefinitions	colors;
+		/// <summary>Draws above the player/monsters when
+		/// the player is above and vice-versa.</summary>
+		private bool				useDynamicDepth;
+		/// <summary>The y offset from the position of the tile to the origin.
+		/// Only needed for dynamic depth.</summary>
+		private int					dynamicOriginY;
 
 
 		//-----------------------------------------------------------------------------
@@ -41,6 +47,8 @@ namespace ZeldaOracle.Game.Tiles {
 			this.absoluteDrawPosition		= Vector2F.Zero;
 			this.useAbsoluteDrawPosition	= false;
 			this.colors                     = new ColorDefinitions();
+			this.useDynamicDepth			= false;
+			this.dynamicOriginY				= 0;
 		}
 
 		
@@ -106,19 +114,35 @@ namespace ZeldaOracle.Game.Tiles {
 			if (!isVisible)
 				return;
 
+			// Determine draw position.
+			Vector2F drawPosition = (useAbsoluteDrawPosition ?
+				absoluteDrawPosition : tile.Position);
+
 			// Determine the depth layer based on the tile grid layer.
-			if (tile.Layer == 0)
+			if (useDynamicDepth) {
+				float playerY = Tile.RoomControl.Player.Position.Y;
+				if (Math.Round(playerY) < Math.Round(drawPosition.Y + dynamicOriginY)) {
+					if (tile.Layer == 2)
+						depthLayer = DepthLayer.DynamicDepthAboveTileLayer3;
+					else
+						depthLayer = DepthLayer.DynamicDepthAboveTileLayer2;
+				}
+				else {
+					if (tile.Layer == 2)
+						depthLayer = DepthLayer.DynamicDepthBelowTileLayer3;
+					else
+						depthLayer = DepthLayer.DynamicDepthBelowTileLayer2;
+				}
+			}
+			else if (tile.Layer == 0)
 				depthLayer = DepthLayer.TileLayer1;
 			else if (tile.Layer == 1)
 				depthLayer = DepthLayer.TileLayer2;
 			else if (tile.Layer == 2)
 				depthLayer = DepthLayer.TileLayer3;
-			
-			// Determine draw position.
-			Vector2F drawPosition = (useAbsoluteDrawPosition ?
-				absoluteDrawPosition : tile.Position);
+
 			drawPosition += (raisedDrawOffset + drawOffset);
-						
+
 			// Draw the tile's as-object sprite.
 			if (tile.IsMoving && tile.SpriteAsObject != null) {
 				g.DrawSprite(tile.SpriteAsObject, new SpriteDrawSettings(colors,
@@ -231,6 +255,20 @@ namespace ZeldaOracle.Game.Tiles {
 
 		public ColorDefinitions Colors {
 			get { return colors; }
+		}
+
+		/// <summary>Gets if the t draws above the player/monsters
+		/// when the player is above and vice-versa.</summary>
+		public bool UseDynamicDepth {
+			get { return useDynamicDepth; }
+			set { useDynamicDepth = value; }
+		}
+
+		/// <summary>The y offset from the position of the tile to the origin.
+		/// Only needed for dynamic depth.</summary>
+		public int DynamicOriginY {
+			get { return dynamicOriginY; }
+			set { dynamicOriginY = value; }
 		}
 	}
 }

--- a/ZeldaOracle/GameContent/Tiles/ActionTiles/monsters.conscript
+++ b/ZeldaOracle/GameContent/Tiles/ActionTiles/monsters.conscript
@@ -67,6 +67,7 @@ TILE "monster_beamos";
 	SOLID		block;
 	FLAGS		AbsorbSeeds;
 	SPRITE		"monster_beamos";
+	ENTITYDRAW	true;
 END;
 
 TILE "monster_flying_tile";

--- a/ZeldaOracle/GameContent/Tiles/Tiles/Objects/entity_objects.conscript
+++ b/ZeldaOracle/GameContent/Tiles/Tiles/Objects/entity_objects.conscript
@@ -49,6 +49,7 @@ END;
 TILE "temp_crossing_grate";
 	TYPE		TileCrossingGate;
 	SOLID		edge_w;
+	ENTITYDRAW	true;
 	PROPERTIES	(boolean, raised,    false, "Raised",      "", "Crossing Gate", "True if the gate is raised."),
 				(boolean, face_left, false, "Facing Left", "", "Crossing Gate", "True if the crossing gate is facing left."),
 				(boolean, cling_on_stab, false);


### PR DESCRIPTION
* Added dynamic depth which allows the entity or tile to draw below or
above the player and monsters based on the player's position.
* Cross Guard now draws above and below the player using dynamic depth.
* Added DrawAsEntity to tile data to allow tiles to draw with the entity
group, negating visual effects and enabling dynamic depth. The command
in the conscript designer is ENTITYDRAW true;
* Beamos now drawn with entities.
* TileMinecartTrack now draws minecart when present in editor.