### PR TITLE
Improve Side-Scrolling Somaria Block

### DIFF
--- a/ZeldaOracle/Game/Game/Tiles/Custom/SideScroll/TileDisappearingPlatform.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Custom/SideScroll/TileDisappearingPlatform.cs
@@ -90,8 +90,8 @@ namespace ZeldaOracle.Game.Tiles.Custom.SideScroll {
 		private static Properties GetSyncedProperties(Properties properties, Room room) {
 			string syncName = properties.GetString("sync_with", "");
 			if (!string.IsNullOrWhiteSpace(syncName)) {
-				TileDataInstance tile = room.FindTileByID(syncName);
-				if (tile != null /*&& tile.Type == typeof(TileDisappearingPlatform)*/)
+				TileDataInstance tile = room.FindTileOfTypeByID<TileDisappearingPlatform>(syncName);
+				if (tile != null)
 					return tile.Properties;
 			}
 			return properties;
@@ -111,9 +111,6 @@ namespace ZeldaOracle.Game.Tiles.Custom.SideScroll {
 			int timeDisappear = GMath.Wrap((int) time - disappearTime, GameSettings.TILE_DISAPPEARING_PLATFORM_APPEAR_DURATION);
 			int appearEnd = CalcAppearEnd(appearTime, disappearTime, duration);
 			int disappearEnd = CalcDisappearEnd(appearTime, disappearTime, duration);
-			if (duration == 331) {
-				//Console.WriteLine("AppearEnd: " + appearEnd + " - DisappearEnd: " + disappearEnd);
-			}
 			if (IsAppearing(time, appearTime, disappearTime, duration))
 				return timeAppear % 2 == 1;
 			else if (IsDisappearing(time, appearTime, disappearTime, duration))

--- a/ZeldaOracle/Game/Game/Tiles/Custom/TileSomariaBlock.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Custom/TileSomariaBlock.cs
@@ -12,11 +12,15 @@ namespace ZeldaOracle.Game.Tiles {
 
 
 		public TileSomariaBlock() {
-
+			// TODO: Break when getting crushed by Thwomp. (Only when moving)
 		}
 
 		public override void OnInitialize() {
 			DropList = null;
+			CancelBreakSound = true;
+			CheckSurfaceTile();
+			CancelBreakSound = false;
+			// TODO: Prevent spawning on top of entities
 		}
 
 		public override void OnFallInHole() {
@@ -28,6 +32,10 @@ namespace ZeldaOracle.Game.Tiles {
 		}
 		
 		public override void OnFallInLava() {
+			Break(false);
+		}
+
+		public override void OnFloating() {
 			Break(false);
 		}
 

--- a/ZeldaOracle/Game/Game/Worlds/Room.cs
+++ b/ZeldaOracle/Game/Game/Worlds/Room.cs
@@ -160,6 +160,20 @@ namespace ZeldaOracle.Game.Worlds {
 			return actionData.Find(actionTile => actionTile.ID == actionTileID);
 		}
 
+		public TileDataInstance FindTileOfTypeByID<TileType>(string tileID) {
+			for (int layer = 0; layer < LayerCount; layer++) {
+				for (int x = 0; x < Width; x++) {
+					for (int y = 0; y < Height; y++) {
+						TileDataInstance tile = tileData[x, y, layer];
+						if (tile != null && tile.IsAtLocation(x, y) &&
+							tile.ID == tileID && tile.Type.Equals(typeof(TileType)))
+							return tile;
+					}
+				}
+			}
+			return null;
+		}
+
 		public TileDataInstance FindTileByID(string tileID) {
 			for (int layer = 0; layer < LayerCount; layer++) {
 				for (int x = 0; x < Width; x++) {


### PR DESCRIPTION
* Disappearing platform now only tries to sync with tiles of the same
type.
* Added SideScrolling IsFloating check to Tile.CheckSurfaceType().
* Somaria Block now breaks when floating.
* Blocks can no longer be pushed vertically in side-scrolling
environments.
* Somaria Block properly checks it's surface when being spawned again.
* Somaria Block will no longer play the poof sound when failing to
spawn, now in all instances.
* TODO: Somaria Block cannot be spawned on entities.
* TODO: Somaria Block should be crushed by Thwomp (only when moving).