### PR TITLE
Add TileFireShooter (Basic implementation)

### DIFF
--- a/ZeldaOracle/Game/Common/Geometry/Align.cs
+++ b/ZeldaOracle/Game/Common/Geometry/Align.cs
@@ -8,17 +8,66 @@ namespace ZeldaOracle.Common.Geometry {
 	[Flags]
 	public enum Align {
 
-		Center		= 0,
-		Left		= 1,
-		Right		= 2,
-		Top			= 4,
-		Bottom		= 8,
+		Center		= 0x0,
+		Left		= 0x1,
+		Right		= 0x2,
+		Top			= 0x4,
+		Bottom		= 0x8,
 		TopLeft		= Top | Left,
 		TopRight	= Top | Right,
 		BottomLeft	= Bottom | Left,
 		BottomRight	= Bottom | Right,
 
-		Int = 16
+		Int = 0x10,
 
+	}
+
+	/// <summary>A static class for use with the Align enumeration.</summary>
+	public static class Alignment {
+
+		/// <summary>Aligns a point.</summary>
+		/// <param name="position">The initial position.</param>
+		/// <param name="area">The size of the area to align to.</param>
+		/// <param name="size">The size of the object being aligned.</param>
+		/// <param name="alignment">The alignment settings.</param>
+		public static Point2I AlignPoint(Point2I position, Point2I area, Point2I size, Align alignment) {
+			if (alignment.HasFlag(Align.Left)) { }
+			else if (alignment.HasFlag(Align.Right))
+				position.X += area.X - size.X;
+			else
+				position.X += (area.X - size.X) / 2;
+
+			if (alignment.HasFlag(Align.Top)) { }
+			else if (alignment.HasFlag(Align.Bottom))
+				position.Y += area.Y - size.Y;
+			else
+				position.Y += (area.Y - size.Y) / 2;
+
+			return position;
+		}
+
+		/// <summary>Aligns a vector.</summary>
+		/// <param name="position">The initial position.</param>
+		/// <param name="area">The size of the area to align to.</param>
+		/// <param name="size">The size of the object being aligned.</param>
+		/// <param name="alignment">The alignment settings.</param>
+		public static Vector2F AlignVector(Vector2F position, Vector2F area, Vector2F size, Align alignment) {
+			if (alignment.HasFlag(Align.Left)) { }
+			else if (alignment.HasFlag(Align.Right))
+				position.X += area.X - size.X;
+			else
+				position.X += (area.X - size.X) / 2;
+
+			if (alignment.HasFlag(Align.Top)) { }
+			else if (alignment.HasFlag(Align.Bottom))
+				position.Y += area.Y - size.Y;
+			else
+				position.Y += (area.Y - size.Y) / 2;
+
+			if (alignment.HasFlag(Align.Int))
+				position = GMath.Floor(position);
+
+			return position;
+		}
 	}
 } // end namespace

--- a/ZeldaOracle/Game/Common/Graphics/Graphics2D.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Graphics2D.cs
@@ -335,42 +335,104 @@ namespace ZeldaOracle.Common.Graphics {
 			spriteBatch.DrawString(font, text, NewStringPos(position, font, text, alignment), (XnaColor)color, (float)rotation, (Vector2)origin, (Vector2)scale, flipEffect, depth);
 		}
 
-		/// <summary>Draws a game string at the specified position.</summary>
-		public void DrawString(GameFont font, string text, Point2I position, ColorOrPalette color, float depth = 0.0f) {
-			DrawLetterString(font, FormatCodes.FormatString(text), position, color, depth);
+		/// <summary>Draws a game string of any type at the specified position.</summary>
+		public void DrawString(GameFont font, DrawableString text, Vector2F position, ColorOrPalette color, float depth = 0.0f) {
+			DrawString(font, text, position, color, Align.TopLeft, Vector2F.Zero, depth);
+		}
+
+		/// <summary>Draws a game string of any type at the specified position.</summary>
+		public void DrawString(GameFont font, DrawableString text, Vector2F position, ColorOrPalette color, Align alignment, float depth = 0.0f) {
+			DrawString(font, text, position, color, alignment, Vector2F.Zero, depth);
+		}
+
+		/// <summary>Draws a game string of any type at the specified position.</summary>
+		public void DrawString(GameFont font, DrawableString text, Vector2F position, ColorOrPalette color, Align alignment, Vector2F area, float depth = 0.0f) {
+			if (text.IsString)
+				DrawLetterString(font, FormatCodes.FormatString(text.String), position, color, alignment, area, depth);
+			else if (text.IsLetterString)
+				DrawLetterString(font, text.LetterString, position, color, alignment, area, depth);
+			else if (text.IsWrappedLetterString)
+				DrawWrappedLetterString(font, text.WrappedLetterString, position, color, alignment, area, depth);
 		}
 
 		/// <summary>Draws a formatted game string at the specified position.</summary>
-		public void DrawLetterString(GameFont font, LetterString letterString, Point2I position, ColorOrPalette color, float depth = 0.0f) {
+		public void DrawLetterString(GameFont font, LetterString letterString, Vector2F position, ColorOrPalette color, float depth = 0.0f) {
+			DrawLetterString(font, letterString, position, color, Align.TopLeft, Vector2F.Zero, depth);
+		}
+
+		/// <summary>Draws a formatted game string at the specified position.</summary>
+		public void DrawLetterString(GameFont font, LetterString letterString, Vector2F position, ColorOrPalette color, Align alignment, float depth = 0.0f) {
+			DrawLetterString(font, letterString, position, color, alignment, Vector2F.Zero, depth);
+		}
+
+		/// <summary>Draws a formatted game string at the specified position.</summary>
+		public void DrawLetterString(GameFont font, LetterString letterString, Vector2F position, ColorOrPalette color, Align alignment, Vector2F area, float depth = 0.0f) {
+			Vector2F size = font.MeasureString(letterString);
+			position = Alignment.AlignVector(position, area, size, alignment);
 			for (int i = 0; i < letterString.Length; i++) {
 				spriteBatch.Draw(
 					font.SpriteSheet.Image,
-					NewRect(new Rectangle2I(
-						position.X + i * (font.SpriteSheet.CellSize.X + font.CharacterSpacing),
+					NewRect(new Rectangle2F(
+						position.X + i * (font.CharacterWidth + font.CharacterSpacing),
 						position.Y,
-						font.SpriteSheet.CellSize.X,
-						font.SpriteSheet.CellSize.Y
+						font.CharacterSize
 					)),
-					(Rectangle)new Rectangle2I(
-						font.SpriteSheet.Offset.X + ((int)letterString[i].Char % font.CharactersPerRow) * (font.SpriteSheet.CellSize.X + font.SpriteSheet.Spacing.X),
-						font.SpriteSheet.Offset.Y + ((int)letterString[i].Char / font.CharactersPerRow) * (font.SpriteSheet.CellSize.Y + font.SpriteSheet.Spacing.Y),
-						font.SpriteSheet.CellSize.X,
-						font.SpriteSheet.CellSize.Y
-					),
+					(Rectangle) font.GetCharacterCell(letterString[i].Char),
 					(letterString[i].Color == Letter.DefaultColor ? color.MappedColor : letterString[i].MappedColor), 0.0f, Vector2.Zero, SpriteEffects.None, depth
 				);
 			}
 		}
 
-		/// <summary>Draws a wrapped game string at the specified position.</summary>
-		public void DrawWrappedString(GameFont font, string text, int width, Point2I position, ColorOrPalette color, float depth = 0.0f) {
-			DrawWrappedLetterString(font, font.WrapString(text, width), width, position, color, depth);
+		/// <summary>Draws a wrapped game string of any type at the specified position.</summary>
+		public void DrawWrappedString(GameFont font, DrawableString text, Vector2F position, ColorOrPalette color, float depth = 0.0f) {
+			DrawWrappedString(font, text, position, color, Align.TopLeft, Vector2F.Zero, depth);
+		}
+
+		/// <summary>Draws a wrapped game string of any type at the specified position.</summary>
+		public void DrawWrappedString(GameFont font, DrawableString text, Vector2F position, ColorOrPalette color, Align alignment, float depth = 0.0f) {
+			DrawWrappedString(font, text, position, color, alignment, Vector2F.Zero, depth);
+		}
+
+		/// <summary>Draws a wrapped game string of any type at the specified position.</summary>
+		public void DrawWrappedString(GameFont font, DrawableString text, Vector2F position, ColorOrPalette color, Align alignment, Vector2F area, float depth = 0.0f) {
+			//DrawWrappedLetterString(font, font.WrapString(text, width), position, color, depth);
+			if (text.IsString)
+				DrawWrappedLetterString(font, font.WrapString(text.String, (int) area.X), position, color, alignment, area, depth);
+			else if (text.IsLetterString)
+				DrawLetterString(font, text.LetterString, position, color, alignment, area, depth);
+			else if (text.IsWrappedLetterString)
+				DrawWrappedLetterString(font, text.WrappedLetterString, position, color, alignment, area, depth);
 		}
 
 		/// <summary>Draws a formatted wrapped game string at the specified position.</summary>
-		public void DrawWrappedLetterString(GameFont font, WrappedLetterString wrappedString, int width, Point2I position, ColorOrPalette color, float depth = 0.0f) {
-			for (int i = 0; i < wrappedString.Lines.Length; i++) {
-				DrawLetterString(font, wrappedString.Lines[i], position + new Point2I(0, font.LineSpacing * i), color, depth);
+		public void DrawWrappedLetterString(GameFont font, WrappedLetterString wrappedString, Vector2F position, ColorOrPalette color, float depth = 0.0f) {
+			DrawWrappedLetterString(font, wrappedString, position, color, Align.TopLeft, Vector2F.Zero, depth);
+		}
+
+		/// <summary>Draws a formatted wrapped game string at the specified position.</summary>
+		public void DrawWrappedLetterString(GameFont font, WrappedLetterString wrappedString, Vector2F position, ColorOrPalette color, Align alignment, float depth = 0.0f) {
+			DrawWrappedLetterString(font, wrappedString, position, color, alignment, Vector2F.Zero, depth);
+		}
+
+		/// <summary>Draws a formatted wrapped game string at the specified position.</summary>
+		public void DrawWrappedLetterString(GameFont font, WrappedLetterString wrappedString, Vector2F position, ColorOrPalette color, Align alignment, Vector2F area, float depth = 0.0f) {
+			Vector2F size = font.MeasureString(wrappedString);
+			Vector2F originalPosition = position;
+			for (int j = 0; j < wrappedString.LineCount; j++) {
+				LetterString letterString = wrappedString.Lines[j];
+				position = Alignment.AlignVector(originalPosition, area, new Vector2F(wrappedString.LineLengths[j], size.Y), alignment);
+				for (int i = 0; i < letterString.Length; i++) {
+					spriteBatch.Draw(
+						font.SpriteSheet.Image,
+						NewRect(new Rectangle2F(
+							position.X + i * (font.CharacterWidth + font.CharacterSpacing),
+							position.Y + j * (font.CharacterHeight + font.LineSpacing),
+							font.CharacterSize
+						)),
+						(Rectangle) font.GetCharacterCell(letterString[i].Char),
+						(letterString[i].Color == Letter.DefaultColor ? color.MappedColor : letterString[i].MappedColor), 0.0f, Vector2.Zero, SpriteEffects.None, depth
+					);
+				}
 			}
 		}
 

--- a/ZeldaOracle/Game/Common/Translation/LetterString.cs
+++ b/ZeldaOracle/Game/Common/Translation/LetterString.cs
@@ -5,6 +5,149 @@ using System.Text;
 using ZeldaOracle.Common.Graphics;
 
 namespace ZeldaOracle.Common.Translation {
+
+	/// <summary>A structure that contains either a string, LetterString or WrappedLetterString.</summary>
+	public struct DrawableString {
+
+		//-----------------------------------------------------------------------------
+		// Constants
+		//-----------------------------------------------------------------------------
+
+		/// <summary>A null drawable string.</summary>
+		public static readonly DrawableString Null = new DrawableString((string) null);
+
+
+		//-----------------------------------------------------------------------------
+		// Members
+		//-----------------------------------------------------------------------------
+
+		/// <summary>The object storing either a string, LetterString, or WrappedLetterString.
+		/// This value can be null.</summary>
+		private object value;
+		
+
+		//-----------------------------------------------------------------------------
+		// Constructors
+		//-----------------------------------------------------------------------------
+
+		/// <summary>Constructs a string.</summary>
+		public DrawableString(string text) {
+			value = text;
+		}
+
+		/// <summary>Constructs a LetterString.</summary>
+		public DrawableString(LetterString letterString) {
+			value = letterString;
+		}
+
+		/// <summary>Constructs a WrappedLetterString.</summary>
+		public DrawableString(WrappedLetterString letterString) {
+			value = letterString;
+		}
+
+		
+		//-----------------------------------------------------------------------------
+		// General
+		//-----------------------------------------------------------------------------
+
+		/// <summary>Gets the hash code for the text.</summary>
+		public override int GetHashCode() {
+			return value.GetHashCode();
+		}
+
+		/// <summary>Returns true if the object is equal to the string,
+		/// LetterString, or WrappedString.</summary>
+		public override bool Equals(object obj) {
+			if (obj is string)
+				return (string) value == (string) obj;
+			else if (obj is LetterString)
+				return value == obj;
+			else if (obj is WrappedLetterString)
+				return value == obj;
+			else if (obj is DrawableString)
+				return this == ((DrawableString) obj);
+			else if (obj == null)
+				return value == null;
+			return false;
+		}
+
+
+		//-----------------------------------------------------------------------------
+		// Operators
+		//-----------------------------------------------------------------------------
+
+		public static bool operator ==(DrawableString a, DrawableString b) {
+			if (a.value is string && b.value is string)
+				return (string) a.value == (string) b.value;
+			else
+				return a.value == b.value;
+		}
+
+		public static bool operator !=(DrawableString a, DrawableString b) {
+			if (a.value is string && b.value is string)
+				return (string) a.value != (string) b.value;
+			else
+				return a.value != b.value;
+		}
+
+
+		//-----------------------------------------------------------------------------
+		// Implicit Conversion
+		//-----------------------------------------------------------------------------
+
+		public static implicit operator DrawableString(string text) {
+			return new DrawableString(text);
+		}
+
+		public static implicit operator DrawableString(LetterString letterString) {
+			return new DrawableString(letterString);
+		}
+
+		public static implicit operator DrawableString(WrappedLetterString letterString) {
+			return new DrawableString(letterString);
+		}
+		
+
+		//-----------------------------------------------------------------------------
+		// Properties
+		//-----------------------------------------------------------------------------
+
+		/// <summary>Returns true if the value is null.</summary>
+		public bool IsNull {
+			get { return value == null; }
+		}
+
+		/// <summary>Returns true if the value is a string.</summary>
+		public bool IsString {
+			get { return value is string; }
+		}
+
+		/// <summary>Gets the value as a string.</summary>
+		public string String {
+			get { return value as string; }
+		}
+
+		/// <summary>Returns true if the value is a LetterString.</summary>
+		public bool IsLetterString {
+			get { return value is LetterString; }
+		}
+
+		/// <summary>Gets the value as a LetterString.</summary>
+		public LetterString LetterString {
+			get { return value as LetterString; }
+		}
+
+		/// <summary>Returns true if the value is a WrappedLetterString.</summary>
+		public bool IsWrappedLetterString {
+			get { return value is WrappedLetterString; }
+		}
+
+		/// <summary>Gets the value as a WrappedLetterString.</summary>
+		public WrappedLetterString WrappedLetterString {
+			get { return value as WrappedLetterString; }
+		}
+	}
+
 	/// <summary>A formatted game letter with a color and character</summary>
 	public struct Letter {
 

--- a/ZeldaOracle/Game/Game/Entities/PhysicsComponent.cs
+++ b/ZeldaOracle/Game/Game/Entities/PhysicsComponent.cs
@@ -195,6 +195,16 @@ namespace ZeldaOracle.Game.Entities {
 			}
 		}
 
+		// Return a list of solid entities colliding with this entity.
+		public IEnumerable<T> GetSolidEntitiesMeeting<T>(CollisionBoxType collisionBoxType, int maxZDistance = 10) where T : Entity {
+			CollisionTestSettings settings = new CollisionTestSettings(typeof(T), collisionBoxType, maxZDistance);
+			for (int i = 0; i < entity.RoomControl.Entities.Count; i++) {
+				T other = entity.RoomControl.Entities[i] as T;
+				if (other != null && other.Physics.IsSolid && CollisionTest.PerformCollisionTest(entity, other, settings).IsColliding)
+					yield return other;
+			}
+		}
+
 		// Return a list of entities colliding with this entity.
 		public IEnumerable<T> GetEntitiesMeeting<T>(CollisionBoxType collisionBoxType, int maxZDistance = 10) where T : Entity {
 			CollisionTestSettings settings = new CollisionTestSettings(typeof(T), collisionBoxType, maxZDistance);

--- a/ZeldaOracle/Game/Game/Entities/Projectiles/MonsterProjectiles/FireShooterProjectile.cs
+++ b/ZeldaOracle/Game/Game/Entities/Projectiles/MonsterProjectiles/FireShooterProjectile.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ZeldaOracle.Common.Audio;
+using ZeldaOracle.Common.Geometry;
+using ZeldaOracle.Game.Entities.Effects;
+using ZeldaOracle.Game.Entities.Players;
+using ZeldaOracle.Game.Tiles;
+
+namespace ZeldaOracle.Game.Entities.Projectiles.MonsterProjectiles {
+
+	public class FireShooterProjectile : Projectile {
+
+		private static readonly int[] PHASE_DURATIONS = { 10, 14 };
+
+		private int phase;
+		private int damage;
+		private int timer;
+
+		//-----------------------------------------------------------------------------
+		// Constructors
+		//-----------------------------------------------------------------------------
+
+		public FireShooterProjectile() {
+			projectileType  = ProjectileType.Magic;
+			crashAnimation  = null;
+			syncAnimationWithDirection = true;
+			damage          = 6;
+			Graphics.DepthLayer = DepthLayer.ProjectileBeam;
+
+			// Physics
+			Physics.CollisionBox		= new Rectangle2F(-2, 2, 4, 4);
+			Physics.SoftCollisionBox    = new Rectangle2F(-1, 1, 2, 2);
+			EnablePhysics(
+				PhysicsFlags.CollideWorld |
+				PhysicsFlags.LedgePassable |
+				PhysicsFlags.HalfSolidPassable |
+				PhysicsFlags.DestroyedOutsideRoom);
+
+			// TODO: Confirm accuracy of collision boxes.
+			// NOTE: Speed is not an identical match as the projectile
+			// speeds up and slows down differently for all 3 phases.
+			// Speed is also designed to slow down once it reached the
+			// tile it was going to collide with in dungeon 5.
+			// AKA: It's speed was only designed for one use scenario.
+
+			phase = 0;
+			timer = 0;
+		}
+
+
+		//-----------------------------------------------------------------------------
+		// Overridden Methods
+		//-----------------------------------------------------------------------------
+
+		public override void Initialize() {
+			base.Initialize();
+
+			Physics.Velocity = Directions.ToVector(direction) * 2f;
+			Graphics.PlayAnimation(GameData.ANIM_PROJECTILE_TILE_FIRE_SHOOTER_SMALL);
+		}
+
+		public override void Update() {
+			base.Update();
+
+			if (phase < 2 && timer >= PHASE_DURATIONS[phase]) {
+				phase++;
+				timer = 0;
+				if (phase == 1) {
+					switch (direction) {
+					case Directions.Down:
+						Physics.CollisionBox = new Rectangle2F(-4, -4, 8, 8); break;
+					}
+					Physics.CollisionBox        = new Rectangle2F(-2, -2, 4, 4);
+					Physics.SoftCollisionBox    = new Rectangle2F(-4, -4, 8, 8);
+					Physics.Velocity = Directions.ToVector(direction) * 3f;
+					Graphics.PlayAnimation(GameData.ANIM_PROJECTILE_TILE_FIRE_SHOOTER_MEDIUM);
+				}
+				else {
+					Physics.CollisionBox        = new Rectangle2F(-4, -4, 8, 8);
+					Physics.SoftCollisionBox    = new Rectangle2F(-6, -6, 12, 12);
+					Physics.Velocity = Directions.ToVector(direction) * 1.5f;
+					Graphics.PlayAnimation(GameData.ANIM_PROJECTILE_TILE_FIRE_SHOOTER_LARGE);
+				}
+			}
+			timer++;
+		}
+
+		public override void OnCollidePlayer(Player player) {
+			player.Hurt(damage, position);
+		}
+
+		public override void OnCollideTile(Tile tile, bool isInitialCollision) {
+			Destroy();
+		}
+
+		public override void OnCollideSolidEntity(Entity entity) {
+			//if (entity is MagnetBall) {
+				Effect effect = new Effect(GameData.ANIM_EFFECT_BLOCK_POOF,
+							Entities.DepthLayer.EffectSomariaBlockPoof);
+				RoomControl.SpawnEntity(effect, Position);
+				AudioSystem.PlaySound(GameData.SOUND_APPEAR_VANISH);
+			//}
+			Destroy();
+		}
+	}
+}

--- a/ZeldaOracle/Game/Game/GameData.Animations.cs
+++ b/ZeldaOracle/Game/Game/GameData.Animations.cs
@@ -244,7 +244,11 @@ namespace ZeldaOracle.Game {
 		public static Animation ANIM_PROJECTILE_MONSTER_FIREBALL;
 		public static Animation ANIM_PROJECTILE_MONSTER_BONE;
 		public static Animation ANIM_PROJECTILE_MONSTER_ROCK;
-	
+
+		public static Animation ANIM_PROJECTILE_TILE_FIRE_SHOOTER_SMALL;
+		public static Animation ANIM_PROJECTILE_TILE_FIRE_SHOOTER_MEDIUM;
+		public static Animation ANIM_PROJECTILE_TILE_FIRE_SHOOTER_LARGE;
+
 		// Effect animations.
 		public static Animation ANIM_EFFECT_DIRT;
 		public static Animation ANIM_EFFECT_WATER_SPLASH;

--- a/ZeldaOracle/Game/Game/Tiles/Custom/TileFireShooter.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Custom/TileFireShooter.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ZeldaOracle.Common.Audio;
+using ZeldaOracle.Common.Geometry;
+using ZeldaOracle.Common.Graphics;
+using ZeldaOracle.Game.Entities.Projectiles;
+using ZeldaOracle.Game.Entities.Projectiles.MonsterProjectiles;
+
+namespace ZeldaOracle.Game.Tiles.Custom {
+	public class TileFireShooter : Tile {
+
+		public const int SHOOT_INVTERVAL = 16;
+		public const int SHOOT_TIMER_OFFSET = 7;
+
+
+		//-----------------------------------------------------------------------------
+		// Constructor
+		//-----------------------------------------------------------------------------
+
+		public TileFireShooter() { }
+
+
+		//-----------------------------------------------------------------------------
+		// Overridden methods
+		//-----------------------------------------------------------------------------
+
+		public override void OnInitialize() {
+			
+		}
+
+		public override void Update() {
+			int time = RoomControl.CurrentRoomTicks;
+			// Every other tile shoots at a slightly different time.
+			if ((Location.X + Location.Y) % 2 == 0)
+				time += SHOOT_INVTERVAL - SHOOT_TIMER_OFFSET;
+			time %= SHOOT_INVTERVAL;
+
+			if (time == 0) {
+				// Shoot a fireball
+				FireShooterProjectile projectile = new FireShooterProjectile();
+				ShootFromDirection(projectile, Direction, 2f, Directions.ToVector(Direction) * 2);
+				AudioSystem.PlaySound(GameData.SOUND_MONSTER_DIE);
+			}
+		}
+
+
+		//-----------------------------------------------------------------------------
+		// Properties
+		//-----------------------------------------------------------------------------
+
+		public int Direction {
+			get { return Properties.GetInteger("direction", Directions.Down); }
+		}
+
+
+		//-----------------------------------------------------------------------------
+		// Projectiles
+		//-----------------------------------------------------------------------------
+		
+		public Projectile ShootFromDirection(Projectile projectile, int direction, float speed, Vector2F positionOffset, int zPositionOffset = 0) {
+			//projectile.Owner        = this;
+			projectile.TileOwner	= this;
+			projectile.Direction	= direction;
+			projectile.Physics.Velocity = Directions.ToVector(direction) * speed;
+			RoomControl.SpawnEntity(projectile, Center + positionOffset, zPositionOffset);
+			return projectile;
+		}
+
+
+		//-----------------------------------------------------------------------------
+		// Static Methods
+		//-----------------------------------------------------------------------------
+
+		/// <summary>Draws the tile data to display in the editor.</summary>
+		public new static void DrawTileData(Graphics2D g, TileDataDrawArgs args) {
+			Tile.DrawTileData(g, args);
+		}
+	}
+}

--- a/ZeldaOracle/Game/Zelda.csproj
+++ b/ZeldaOracle/Game/Zelda.csproj
@@ -390,6 +390,7 @@
     <Compile Include="Game\Entities\Projectiles\MonsterProjectiles\BeamProjectile.cs" />
     <Compile Include="Game\Entities\Projectiles\MonsterProjectiles\FireballProjectile.cs" />
     <Compile Include="Game\Entities\Projectiles\MonsterProjectiles\BoneProjectile.cs" />
+    <Compile Include="Game\Entities\Projectiles\MonsterProjectiles\FireShooterProjectile.cs" />
     <Compile Include="Game\Entities\Projectiles\PlayerProjectiles\PlayerBoomerang.cs" />
     <Compile Include="Game\Entities\Projectiles\MonsterProjectiles\MagicProjectile.cs" />
     <Compile Include="Game\Entities\Projectiles\MonsterProjectiles\MonsterBoomerang.cs" />
@@ -500,6 +501,7 @@
     <Compile Include="Game\Tiles\Custom\Monsters\TileMonsterBeamos.cs" />
     <Compile Include="Game\Tiles\Custom\SideScroll\TileConveyorBelt.cs" />
     <Compile Include="Game\Tiles\Custom\SideScroll\TileDisappearingPlatform.cs" />
+    <Compile Include="Game\Tiles\Custom\TileFireShooter.cs" />
     <Compile Include="Game\Tiles\Tileset.cs" />
     <Compile Include="Game\Tiles\TileDataDrawing.cs" />
     <Compile Include="Game\UserSettings.cs" />

--- a/ZeldaOracle/GameContent/Fonts/fonts.conscript
+++ b/ZeldaOracle/GameContent/Fonts/fonts.conscript
@@ -4,12 +4,12 @@
 
 FONT "large", "Fonts/font_large";
 	GRID (8, 12), (1, 1), (1, 1);
-	SPACING 0, 16, 16;
+	SPACING 0, 0, 16;
 END;
 
 FONT "small", "Fonts/font_small";
 	GRID (8, 8), (1, 1), (1, 1);
-	SPACING 0, 12, 16;
+	SPACING 0, 0, 16;
 END;
 
 

--- a/ZeldaOracle/GameContent/Sprites/Effects/color_effects.conscript
+++ b/ZeldaOracle/GameContent/Sprites/Effects/color_effects.conscript
@@ -156,3 +156,22 @@ ANIMATION "effect_color_flame_green"; SUBSTRIP repeat;
 ANIMATION "effect_color_flame_yellow"; SUBSTRIP repeat;
 	CLONE "effect_color_flame";
 	CHANGECOLOR all, "orange"; END;
+	
+ANIMATION "projectile_tile_fire_shooter_small";
+	SUBSTRIP repeat;
+		ADD frame, 2, ((0, 3), "red"); ADD frame, 2, ((0, 3), "orange"); ADD frame, 2, ((0, 3), "inverse_red");
+	SUBSTRIP repeat;
+		ADD frame, 2, ((3, 3), "red"); ADD frame, 2, ((3, 3), "orange"); ADD frame, 2, ((3, 3), "inverse_red");
+	SUBSTRIP repeat;
+		ADD frame, 2, ((2, 3), "red"); ADD frame, 2, ((2, 3), "orange"); ADD frame, 2, ((2, 3), "inverse_red");
+	SUBSTRIP repeat;
+		ADD frame, 2, ((1, 3), "red"); ADD frame, 2, ((1, 3), "orange"); ADD frame, 2, ((1, 3), "inverse_red");
+	OFFSET (-8, -8); END;
+
+ANIMATION "projectile_tile_fire_shooter_medium";
+	CLONE "projectile_tile_fire_shooter_small";
+	SHIFTSOURCE (0, -1); END;
+
+ANIMATION "projectile_tile_fire_shooter_large";
+	CLONE "projectile_tile_fire_shooter_small";
+	SHIFTSOURCE (0, -2); END;

--- a/ZeldaOracle/GameContent/Tiles/Tiles/Objects/puzzle_objects.conscript
+++ b/ZeldaOracle/GameContent/Tiles/Tiles/Objects/puzzle_objects.conscript
@@ -114,8 +114,12 @@ END;
 # Fire Shooter ------------------------------------------------
 
 TILE "temp_fire_shooter";
-	#Type		TileFireShooter;
+	Type		TileFireShooter;
 	SOLID		block;
+	PROPERTIES
+		(integer, direction, 0, "Direction", "direction",
+			"Fire Shooter", "The direction fire is shot in.", false);
+		
 END;
 
 # Tablet Slot -------------------------------------------------
@@ -426,22 +430,22 @@ END;
 TILE "fire_shooter_left";
 	CLONE		"temp_fire_shooter";
 	SAMESPRITE;
-	# left
+	PROPERTIES (integer, direction, 0);
 END;
 TILE "fire_shooter_up";
 	CLONE		"temp_fire_shooter";
 	SAMESPRITE;
-	# up
+	PROPERTIES (integer, direction, 1);
 END;
 TILE "fire_shooter_right";
 	CLONE		"temp_fire_shooter";
 	SAMESPRITE;
-	# right
+	PROPERTIES (integer, direction, 2);
 END;
 TILE "fire_shooter_down";
 	CLONE		"temp_fire_shooter";
 	SAMESPRITE;
-	# down
+	PROPERTIES (integer, direction, 3);
 END;
 
 # Tablet Slot -------------------------------------------------


### PR DESCRIPTION
* Implemented basics of TileFireShooter. TODO: Make it so projectiles do
not collide with owner tiles. At the moment, the projectiles are shot
too far forwards due to snapping.
* TODO: Improve FireShooterProjectile collision boxes.
* Added basic TileOwner property to Projectile.
* Added alignment options to Graphics2D string methods.
* Created DrawableString struct that can be implicitely converted to
from string, LetterString or WrappedLetterString.
* Added ability to draw text instructions in RoomGraphics. Use Case
Example: memes.