### PR TITLE
Eliminate Platform and Viewport Jittering

### DIFF
--- a/ZeldaOracle/Game/Game/Control/RoomControl.cs
+++ b/ZeldaOracle/Game/Game/Control/RoomControl.cs
@@ -600,7 +600,7 @@ namespace ZeldaOracle.Game.Control {
 			UpdateObjects();
 
 			// Update view to follow player.
-			viewControl.PanTo(Player.Center + Player.ViewFocusOffset);
+			viewControl.PanTo(Player.DrawCenter + Player.ViewFocusOffset);
 			
 			if (requestedTransitionDirection >= 0) {
 				// Call the event RoomTransitioning.
@@ -642,7 +642,7 @@ namespace ZeldaOracle.Game.Control {
 				g.DrawSprite(GameData.SPR_HUD_BACKGROUND, viewRect);
 			}
 
-			Vector2F viewTranslation = -GMath.Round(viewControl.ViewPosition);
+			Vector2F viewTranslation = -GameUtil.Bias(viewControl.ViewPosition);
 
 			g.PushTranslation(viewTranslation);
 

--- a/ZeldaOracle/Game/Game/Control/RoomGraphics.cs
+++ b/ZeldaOracle/Game/Game/Control/RoomGraphics.cs
@@ -236,7 +236,7 @@ namespace ZeldaOracle.Game.Entities {
 
 			settings.Styles = StyleDefinitions;
 
-			position = RoundPosition(position);
+			position = GameUtil.Bias(position);
 
 			DrawingInstruction instruction = new DrawingInstruction(
 					sprite, settings, position, depthOrigin);
@@ -285,7 +285,7 @@ namespace ZeldaOracle.Game.Entities {
 			if (font == null || text.IsNull)
 				return;
 			
-			position = RoundPosition(position);
+			position = GameUtil.Bias(position);
 
 			DrawingInstruction instruction = new DrawingInstruction(font, text,
 				position, color, alignment, area, depthOrigin);
@@ -298,12 +298,6 @@ namespace ZeldaOracle.Game.Entities {
 		//-----------------------------------------------------------------------------
 		// Internal Drawing
 		//-----------------------------------------------------------------------------
-
-		/// <summary>There's a bias of 0.001f to account for rounding
-		/// inconsistancies with the value 0.5f.</summary>
-		private Vector2F RoundPosition(Vector2F position) {
-			return GMath.Round(position + 0.001f);
-		}
 
 		/// <summary>Add the instruction to the end of the linked list for its layer.</summary>
 		private void AddInstruction(DrawingInstruction instruction, DepthLayer depth) {

--- a/ZeldaOracle/Game/Game/Debugging/GameDebug.cs
+++ b/ZeldaOracle/Game/Game/Debugging/GameDebug.cs
@@ -378,9 +378,7 @@ namespace ZeldaOracle.Game.Debug {
 					Color collisionBoxColor = Color.Yellow;
 					if (entity is Player && ((Player) entity).Movement.IsOnSideScrollLadder)
 						collisionBoxColor = new Color(255, 160, 0);
-					collisionBox.X = GMath.Round(collisionBox.X + 0.001f);
-					collisionBox.Y = GMath.Round(collisionBox.Y + 0.001f);
-					//collisionBox.Point = GMath.Round(collisionBox.Point);
+					collisionBox.Point = GameUtil.Bias(collisionBox.Point);
 					g.FillRectangle(collisionBox, collisionBoxColor);
 
 					for (int i = 0; i < 4; i++) {

--- a/ZeldaOracle/Game/Game/Entities/Entity.cs
+++ b/ZeldaOracle/Game/Game/Entities/Entity.cs
@@ -261,6 +261,22 @@ namespace ZeldaOracle.Game.Entities {
 			set { position = value; }
 		}
 
+		public Vector2F DrawPosition {
+			get {
+				bool horizontal = Math.Abs(Physics.SurfaceVelocity.X) > GameSettings.EPSILON &&
+										(!Physics.CollisionInfo[Directions.Left].IsColliding &&
+										!Physics.CollisionInfo[Directions.Right].IsColliding);
+				bool vertical = Math.Abs(Physics.SurfaceVelocity.Y) > GameSettings.EPSILON &&
+										(!Physics.CollisionInfo[Directions.Up].IsColliding &&
+										!Physics.CollisionInfo[Directions.Down].IsColliding);
+				Vector2F surfacePosition = Vector2F.Zero;
+				if (horizontal)	surfacePosition.X = Physics.SurfacePosition.X;
+				if (vertical)	surfacePosition.Y = Physics.SurfacePosition.Y;
+				return GameUtil.Bias(surfacePosition) -
+					GameUtil.ReverseBias(surfacePosition - position);
+			}
+		}
+
 		// Gets or sets the x-position of the entity.
 		public float X {
 			get { return position.X; }
@@ -313,6 +329,10 @@ namespace ZeldaOracle.Game.Entities {
 
 		public Vector2F Center {
 			get { return position + centerOffset; }
+		}
+
+		public Vector2F DrawCenter {
+			get { return DrawPosition + centerOffset; }
 		}
 
 		public Vector2F CenterOffset {

--- a/ZeldaOracle/Game/Game/Entities/GraphicsComponent.cs
+++ b/ZeldaOracle/Game/Game/Entities/GraphicsComponent.cs
@@ -201,7 +201,7 @@ namespace ZeldaOracle.Game.Entities
 			if (isShadowVisible && entity.ZPosition >= 1 &&
 				entity.GameControl.RoomTicks % 2 == 0 && !entity.RoomControl.IsSideScrolling)
 			{
-				g.DrawSprite(GameData.SPR_SHADOW, Entity.Position + shadowDrawOffset, DepthLayer.Shadows);
+				g.DrawSprite(GameData.SPR_SHADOW, Entity.DrawPosition + shadowDrawOffset, DepthLayer.Shadows);
 			}
 
 			if (isFlickering && !flickerIsVisible)
@@ -215,29 +215,29 @@ namespace ZeldaOracle.Game.Entities
 			}
 
 			// Draw the sprite/animation.
-			Vector2F drawPosition = Entity.Position - new Vector2F(0, Entity.ZPosition);
+			Vector2F drawPosition = Entity.DrawPosition - new Vector2F(0, Entity.ZPosition);
 			if (unmapped) {
 				if (unmappedSprite != null)
-					g.DrawSprite(unmappedSprite, drawPosition + drawOffset, layer, entity.Position);
+					g.DrawSprite(unmappedSprite, drawPosition + drawOffset, layer, entity.DrawPosition);
 			}
 			else {
 				g.DrawSprite(animationPlayer.SpriteOrSubStrip, new SpriteDrawSettings(
 					finalColorDefinitions, animationPlayer.PlaybackTime),
-					drawPosition + drawOffset, layer, entity.Position);
+					drawPosition + drawOffset, layer, entity.DrawPosition);
 			}
 
 			// Draw the ripples effect.
 			if (isRipplesEffectVisible && entity.Physics.IsEnabled && entity.Physics.IsInPuddle) {
 				g.DrawSprite(GameData.ANIM_EFFECT_RIPPLES,
-					new SpriteDrawSettings((float) entity.GameControl.RoomTicks), entity.Position +
-					ripplesDrawOffset, layer, entity.Position);
+					new SpriteDrawSettings((float) entity.GameControl.RoomTicks), entity.DrawPosition +
+					ripplesDrawOffset, layer, entity.DrawPosition);
 			}
 			
 			// Draw the grass effect.
 			if (isGrassEffectVisible && entity.Physics.IsEnabled && entity.Physics.IsInGrass) {
 				g.DrawSprite(GameData.ANIM_EFFECT_GRASS,
-					new SpriteDrawSettings((float) grassAnimationTicks), entity.Position +
-					grassDrawOffset, layer, entity.Position + new Vector2F(0, 1));
+					new SpriteDrawSettings((float) grassAnimationTicks), entity.DrawPosition +
+					grassDrawOffset, layer, entity.DrawPosition + new Vector2F(0, 1));
 			}
 		}
 

--- a/ZeldaOracle/Game/Game/Entities/PhysicsComponent.cs
+++ b/ZeldaOracle/Game/Game/Entities/PhysicsComponent.cs
@@ -61,6 +61,8 @@ namespace ZeldaOracle.Game.Entities {
 		private float					maxFallSpeed;
 		private Vector2F				velocity;			// XY-Velocity in pixels per frame.
 		private float					zVelocity;			// Z-Velocity in pixels per frame.
+		private Vector2F				surfacePosition;	// Used for draw position rounding to prevent jittering.
+		private Vector2F				surfaceVelocity;	// Used for draw position rounding to prevent jittering.
 		
 		// Collision settings.
 		private Rectangle2F				collisionBox;		// The "hard" collision box, used to collide with solid entities/tiles.
@@ -452,7 +454,7 @@ namespace ZeldaOracle.Game.Entities {
 		}
 
 		public bool CanDodgeCollision(Rectangle2F block, int direction) {
-			if (Math.Abs(velocity.X) > 0.001f && Math.Abs(velocity.Y) > 0.001f)
+			if (GMath.Abs(velocity) > GameSettings.EPSILON)
 				return false; // Only dodge when moving horizontally or vertically.
 
 			float		dodgeDist	= autoDodgeDistance;
@@ -877,6 +879,16 @@ namespace ZeldaOracle.Game.Entities {
 		public float NetVelocityY {
 			get { return netVelocity.Y; }
 			set { netVelocity.Y = value; }
+		}
+
+		public Vector2F SurfacePosition {
+			get { return surfacePosition; }
+			set { surfacePosition = value; }
+		}
+
+		public Vector2F SurfaceVelocity {
+			get { return surfaceVelocity; }
+			set { surfaceVelocity = value; }
 		}
 	}
 }

--- a/ZeldaOracle/Game/Game/Entities/Players/States/PlayerCarryState.cs
+++ b/ZeldaOracle/Game/Game/Entities/Players/States/PlayerCarryState.cs
@@ -215,6 +215,7 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 				}
 			}
 			carryObject.Graphics.Update();
+			carryObject.Physics.SurfacePosition = player.Physics.SurfacePosition;
 		}
 		
 		public override void DrawOver(RoomGraphics g) {
@@ -232,6 +233,7 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 			}
 
 			// Draw the object.
+			carryObject.Physics.SurfacePosition = player.Physics.SurfacePosition;
 			carryObject.Graphics.Draw(g, DepthLayer.ProjectileCarriedTile);
 		}
 

--- a/ZeldaOracle/Game/Game/Entities/Units/Unit.cs
+++ b/ZeldaOracle/Game/Game/Entities/Units/Unit.cs
@@ -289,7 +289,7 @@ namespace ZeldaOracle.Game.Entities.Units {
 			// Draw tools under.
 			foreach (UnitTool tool in tools) {
 				if (!tool.DrawAboveUnit) {
-					Vector2F drawPosition = position - new Vector2F(0, zPosition) + Graphics.DrawOffset + tool.DrawOffset;
+					Vector2F drawPosition = DrawPosition - new Vector2F(0, zPosition) + Graphics.DrawOffset + tool.DrawOffset;
 					g.DrawAnimationPlayer(tool.AnimationPlayer, drawPosition, depthLayer, position);
 				}
 			}
@@ -300,7 +300,7 @@ namespace ZeldaOracle.Game.Entities.Units {
 			// Draw tools over.
 			foreach (UnitTool tool in tools) {
 				if (tool.DrawAboveUnit) {
-					Vector2F drawPosition = position - new Vector2F(0, zPosition) + Graphics.DrawOffset + tool.DrawOffset;
+					Vector2F drawPosition = DrawPosition - new Vector2F(0, zPosition) + Graphics.DrawOffset + tool.DrawOffset;
 					g.DrawAnimationPlayer(tool.AnimationPlayer, drawPosition, depthLayer, position);
 				}
 			}

--- a/ZeldaOracle/Game/Game/GameSettings.cs
+++ b/ZeldaOracle/Game/Game/GameSettings.cs
@@ -29,6 +29,12 @@ namespace ZeldaOracle.Game {
 		public static readonly Rectangle2I	SCREEN_BOUNDS			= new Rectangle2I(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
 		public const int					VIEW_PAN_SPEED			= 1;
 
+		/// <summary>The bias used to make sure 0.5 always rounds in the same direction when drawing.</summary>
+		public const float					BIAS					= 0.001f;
+
+		/// <summary>The epsilon value for velocity used in collision dodging.</summary>
+		public const float					EPSILON					= 0.001f;
+
 		// Properties
 		public const string				TEXT_UNDEFINED				= "<red>undefined<red>";
 

--- a/ZeldaOracle/Game/Game/GameStates/Transitions/RoomTransition.cs
+++ b/ZeldaOracle/Game/Game/GameStates/Transitions/RoomTransition.cs
@@ -52,7 +52,7 @@ namespace ZeldaOracle.Game.GameStates.Transitions {
 				eventSetupNewRoom.Invoke(roomNew);
 
 			NewRoomControl.ViewControl.CenterOn(
-				Player.Center + Player.ViewFocusOffset);
+				Player.DrawCenter + Player.ViewFocusOffset);
 
 			// Mark the player's respawn point in the new room.
 			Player.MarkRespawn();

--- a/ZeldaOracle/Game/Game/GameStates/Transitions/RoomTransitionPush.cs
+++ b/ZeldaOracle/Game/Game/GameStates/Transitions/RoomTransitionPush.cs
@@ -67,10 +67,10 @@ namespace ZeldaOracle.Game.GameStates.Transitions {
 			// Wait for the view to pan to the player.
 			if (isWaitingForView) {
 				OldRoomControl.ViewControl.PanTo(
-					Player.Center + Player.ViewFocusOffset);
+					Player.DrawCenter + Player.ViewFocusOffset);
 
 				if (OldRoomControl.ViewControl.IsCenteredOnPosition(
-					Player.Center + Player.ViewFocusOffset))
+					Player.DrawCenter + Player.ViewFocusOffset))
 				{
 					// Convert the player's position from the old room to the
 					// new room.

--- a/ZeldaOracle/Game/Game/GameUtil.cs
+++ b/ZeldaOracle/Game/Game/GameUtil.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ZeldaOracle.Common.Geometry;
+
+namespace ZeldaOracle.Game {
+	/// <summary>The static class for game helper functions.</summary>
+	public static class GameUtil {
+		/// <summary>Rounds the specified vector to the nearest integral coordinates with bias.</summary>
+		public static Vector2F Bias(Vector2F a) {
+			return new Vector2F(
+				(float) Math.Round(a.X + GameSettings.BIAS),
+				(float) Math.Round(a.Y + GameSettings.BIAS));
+		}
+
+		/// <summary>Rounds the specified vector to the nearest integral coordinates with bias.</summary>
+		public static Vector2F ReverseBias(Vector2F a) {
+			return new Vector2F(
+				(float) Math.Round(a.X - GameSettings.BIAS),
+				(float) Math.Round(a.Y - GameSettings.BIAS));
+		}
+	}
+}

--- a/ZeldaOracle/Game/Zelda.csproj
+++ b/ZeldaOracle/Game/Zelda.csproj
@@ -415,6 +415,7 @@
     <Compile Include="Game\GameData.Sounds.cs" />
     <Compile Include="Game\GameData.Sprites.cs" />
     <Compile Include="Game\GameData.Animations.cs" />
+    <Compile Include="Game\GameUtil.cs" />
     <Compile Include="Game\GameStates\RoomStates\RoomStateNormal.cs" />
     <Compile Include="Game\GameStates\RoomStates\RoomStateQueue.cs" />
     <Compile Include="Game\GameStates\RoomStates\RoomStateAction.cs" />


### PR DESCRIPTION
* Platform jittering eliminated through use of Entity's new DrawPosition
and DrawCenter properties. These values rely on Physics.SurfacePosition
and Physics.SurfaceVelocity being set.
* Viewport jittering eliminated by applying bias to view translation.
* Call GameUtil.Bias or GameUtil.ReverseBias to apply draw position
rounding with the GameSettings.BIAS value.