### PR TITLE
Add Monster Diggup Collision Delay

### DIFF
--- a/ZeldaOracle/Game/Game/Entities/Monsters/Monster.cs
+++ b/ZeldaOracle/Game/Game/Entities/Monsters/Monster.cs
@@ -176,6 +176,10 @@ namespace ZeldaOracle.Game.Entities.Monsters {
 		public virtual void UpdateAI() {
 
 		}
+
+		public void BeginSpawnState(int duration = GameSettings.MONSTER_SPAWN_STATE_DURATION) {
+			BeginState(new MonsterSpawnState(duration));
+		}
 		
 		
 		//-----------------------------------------------------------------------------

--- a/ZeldaOracle/Game/Game/Entities/Monsters/MonsterPincer.cs
+++ b/ZeldaOracle/Game/Game/Entities/Monsters/MonsterPincer.cs
@@ -60,7 +60,7 @@ namespace ZeldaOracle.Game.Entities.Monsters {
 			base.Initialize();
 
 			// Begin hiding
-			isPassable = true;
+			IsPassable = true;
 			holePosition = position;
 			Graphics.IsVisible = false;
 			Graphics.PlayAnimation(GameData.ANIM_MONSTER_PINCER_EYES);
@@ -82,7 +82,7 @@ namespace ZeldaOracle.Game.Entities.Monsters {
 				// Check if returned to hole
 				if (vectorToHole.Length < GameSettings.MONSTER_PINCER_RETURN_SPEED) {
 					timer = 0;
-					isPassable = true;
+					IsPassable = true;
 					position = holePosition;
 					physics.Velocity = Vector2F.Zero;
 					Graphics.IsVisible = false;
@@ -110,7 +110,7 @@ namespace ZeldaOracle.Game.Entities.Monsters {
 					Angle = Angles.NearestFromVector(vectorToPlayer);
 					strikeVelocity = Angles.ToVector(Angle) *
 						GameSettings.MONSTER_PINCER_STRIKE_SPEED;
-					isPassable = false;
+					IsPassable = false;
 					Graphics.PlayAnimation(GameData.ANIM_MONSTER_PINCER_HEAD);
 					pincerState = PincerState.Strike;
 				}

--- a/ZeldaOracle/Game/Game/Entities/Monsters/States/MonsterSpawnState.cs
+++ b/ZeldaOracle/Game/Game/Entities/Monsters/States/MonsterSpawnState.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ZeldaOracle.Game.Entities.Monsters.States {
+	public class MonsterSpawnState : MonsterState {
+
+		private int timer;
+		private bool isPassableBefore;
+
+
+		//-----------------------------------------------------------------------------
+		// Constructor
+		//-----------------------------------------------------------------------------
+
+		public MonsterSpawnState(int duration) {
+			this.timer = duration;
+		}
+
+
+		//-----------------------------------------------------------------------------
+		// Overridden Methods
+		//-----------------------------------------------------------------------------
+
+		public override void OnBegin(MonsterState previousState) {
+			isPassableBefore = Monster.IsPassable;
+			Monster.IsPassable = true;
+		}
+
+		public override void OnEnd(MonsterState newState) {
+			Monster.IsPassable = isPassableBefore;
+		}
+
+		public override void Update() {
+			if (timer == 0) {
+				monster.BeginNormalState();
+			}
+			else {
+				Monster.IsPassable = true;
+				Monster.UpdateAI();
+				Monster.IsPassable = true;
+			}
+
+			timer--;
+		}
+	}
+}

--- a/ZeldaOracle/Game/Game/GameSettings.cs
+++ b/ZeldaOracle/Game/Game/GameSettings.cs
@@ -57,7 +57,7 @@ namespace ZeldaOracle.Game {
 		public const int				COLLECTIBLE_ALIVE_DURATION				= 513;
 		public const int				COLLECTIBLE_FADE_DELAY					= 400;
 		public const int				COLLECTIBLE_PICKUPABLE_DELAY			= 12;
-		public const int				COLLECTIBLE_DIG_PICKUPABLE_DELAY		= 16;
+		public const int				COLLECTIBLE_DIG_PICKUPABLE_DELAY		= 20;
 		public const int				COLLECTIBLE_FAIRY_ALIVE_DURATION		= 513;
 		public const int				COLLECTIBLE_FAIRY_FADE_DELAY			= 400;
 		public const int				COLLECTIBLE_FAIRY_HOVER_HEIGHT			= 8;
@@ -91,7 +91,9 @@ namespace ZeldaOracle.Game {
 		public const int				UNIT_HURT_INVINCIBLE_DURATION	= 32;
 		public const int				UNIT_HURT_FLICKER_DURATION		= 32;
 		public const int				UNIT_KNOCKBACK_ANGLE_SNAP_COUNT	= 16;
-		
+
+		public const int				MONSTER_SPAWN_STATE_DURATION		= 31;
+
 		public const float				MONSTER_KNOCKBACK_SPEED				= 2.0f; // 1.3 ??
 		public const int				MONSTER_HURT_KNOCKBACK_DURATION		= 11;
 		public const int				MONSTER_BUMP_KNOCKBACK_DURATION		= 8;

--- a/ZeldaOracle/Game/Game/Tiles/Tile.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Tile.cs
@@ -22,6 +22,7 @@ using ZeldaOracle.Game.Entities.Players;
 using ZeldaOracle.Game.Entities.Collisions;
 using ZeldaOracle.Game.Entities.Projectiles.PlayerProjectiles;
 using ZeldaOracle.Common.Graphics.Sprites;
+using ZeldaOracle.Game.Entities.Monsters;
 
 namespace ZeldaOracle.Game.Tiles {
 
@@ -344,6 +345,9 @@ namespace ZeldaOracle.Game.Tiles {
 			if (dropEntity != null) {
 				if (dropEntity is Collectible)
 					(dropEntity as Collectible).PickupableDelay = GameSettings.COLLECTIBLE_DIG_PICKUPABLE_DELAY;
+				else if (dropEntity is Monster)
+					(dropEntity as Monster).BeginSpawnState();
+
 				dropEntity.Physics.Velocity = Directions.ToVector(direction) * GameSettings.DROP_ENTITY_DIG_VELOCITY;
 			}
 
@@ -435,7 +439,7 @@ namespace ZeldaOracle.Game.Tiles {
 		// Spawn a drop entity based on the random drop-list.
 		public Entity SpawnDrop() {
 			Entity dropEntity = null;
-			
+
 			// Choose a random drop (or none) from the list.
 			if (dropList != null)
 				dropEntity = dropList.CreateDropEntity(GameControl);
@@ -444,7 +448,14 @@ namespace ZeldaOracle.Game.Tiles {
 			if (dropEntity != null) {
 				dropEntity.SetPositionByCenter(Center);
 				dropEntity.Physics.ZVelocity = GameSettings.DROP_ENTITY_SPAWN_ZVELOCITY;
-				RoomControl.SpawnEntity(dropEntity);
+				if (dropEntity is Monster) {
+					RoomControl.ScheduleEvent(2, () => {
+						RoomControl.SpawnEntity(dropEntity);
+					});
+				}
+				else {
+					RoomControl.SpawnEntity(dropEntity);
+				}
 			}
 
 			return dropEntity;

--- a/ZeldaOracle/Game/Zelda.csproj
+++ b/ZeldaOracle/Game/Zelda.csproj
@@ -316,6 +316,7 @@
     <Compile Include="Game\Entities\Monsters\MonsterMovingWizzrobe.cs" />
     <Compile Include="Game\Entities\Monsters\MonsterGopongaFlower.cs" />
     <Compile Include="Game\Entities\Monsters\MonsterAntiFairy.cs" />
+    <Compile Include="Game\Entities\Monsters\States\MonsterSpawnState.cs" />
     <Compile Include="Game\Entities\Monsters\States\MonsterStateMachine.cs" />
     <Compile Include="Game\Entities\Monsters\MonsterWaterTektike.cs" />
     <Compile Include="Game\Entities\Monsters\MonsterWizzrobe.cs" />


### PR DESCRIPTION
* Monsters now wait 31 frames before they collide with the player when
dug up.
* Corrected dig pickupable delay from 16 to 20 frames.
* Monsters now are properly dug up 2 frames after the initial dug tile
is spawned, just like in the game.