### PR TITLE
Fix Biggoron Sword not Cutting first Tile

### DIFF
--- a/ZeldaOracle/Game/Game/Entities/Players/States/SwingStates/PlayerSwingState.cs
+++ b/ZeldaOracle/Game/Game/Entities/Players/States/SwingStates/PlayerSwingState.cs
@@ -185,8 +185,8 @@ namespace ZeldaOracle.Game.Entities.Players.States.SwingStates {
 			
 			// Perform an initial swing tile peak.
 			Vector2F hitPoint = player.Center + (Angles.ToVector(swingAngle, false) * 13);
-			Point2I hitTileLocation = player.RoomControl.GetTileLocation(hitPoint);
-			OnSwingTilePeak(swingAngle, hitTileLocation);
+			//Point2I hitTileLocation = player.RoomControl.GetTileLocation(hitPoint);
+			OnSwingTilePeak(swingAngle, hitPoint);
 			
 			// Invoke any actions set to occur at time 0.
 			if (timedActions.ContainsKey(0))
@@ -280,7 +280,7 @@ namespace ZeldaOracle.Game.Entities.Players.States.SwingStates {
 			// Check for a swing tile peak (tile peaks happen just as the angle is changed).
 			if (changedAngles) {
 				Vector2F hitPoint = player.Center + (Angles.ToVector(swingAngle, false) * 13);
-				Point2I hitTileLocation = player.RoomControl.GetTileLocation(hitPoint);
+				//Point2I hitTileLocation = player.RoomControl.GetTileLocation(hitPoint);
 				OnSwingTilePeak(swingAngle, hitPoint);
 			}
 				

--- a/ZeldaOracle/Game/Game/Entities/Projectiles/Projectile.cs
+++ b/ZeldaOracle/Game/Game/Entities/Projectiles/Projectile.cs
@@ -246,7 +246,7 @@ namespace ZeldaOracle.Game.Entities.Projectiles {
 				}
 				
 				// Collide with the player.
-				if (Physics.IsMeetingEntity(player, CollisionBoxType.Soft)) {
+				if (!player.IsPassable && Physics.IsMeetingEntity(player, CollisionBoxType.Soft)) {
 					OnCollidePlayer(player);
 					if (IsDestroyed)
 						return;


### PR DESCRIPTION
* Fixed swing state feeding initial cut tile point as location instead
of position. Biggoron Sword now cuts first tile in arc like it's
supposed to.
* Projectile's no longer hit player when IsPassable = true.