### PR TITLE
Implement Somaria Block Interactions

### DIFF
--- a/ZeldaOracle/Game/Game/Entities/TileDummy.cs
+++ b/ZeldaOracle/Game/Game/Entities/TileDummy.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ZeldaOracle.Common.Geometry;
+using ZeldaOracle.Game.Tiles;
+
+namespace ZeldaOracle.Game.Entities {
+	public class TileDummy : Entity {
+
+		private Tile tile;
+
+
+		//-----------------------------------------------------------------------------
+		// Constructors
+		//-----------------------------------------------------------------------------
+
+		public TileDummy(Tile tile) {
+			this.tile = tile;
+			Position = tile.Position;
+			centerOffset = tile.Size * GameSettings.TILE_SIZE / 2;
+			Physics.CollisionBox = new Rectangle2F(tile.Size * GameSettings.TILE_SIZE);
+			Physics.SoftCollisionBox = Physics.CollisionBox;
+		}
+
+	}
+}

--- a/ZeldaOracle/Game/Game/Tiles/Custom/SideScroll/TileDisappearingPlatform.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Custom/SideScroll/TileDisappearingPlatform.cs
@@ -46,7 +46,7 @@ namespace ZeldaOracle.Game.Tiles.Custom.SideScroll {
 			IsSolid = IsPlatformSolid;
 			Graphics.IsVisible = IsPlatformVisible;
 
-			if (Time == appearTime && !AudioSystem.IsSoundPlaying(GameData.SOUND_MYSTERY_SEED)) {
+			if (Time == appearTime) {
 				AudioSystem.PlaySound(GameData.SOUND_MYSTERY_SEED);
 			}
 		}

--- a/ZeldaOracle/Game/Zelda.csproj
+++ b/ZeldaOracle/Game/Zelda.csproj
@@ -411,6 +411,7 @@
     <Compile Include="Game\Entities\Projectiles\Projectile.cs" />
     <Compile Include="Game\Entities\Projectiles\Seeds\Seed.cs" />
     <Compile Include="Game\Control\UnitSystem.cs" />
+    <Compile Include="Game\Entities\TileDummy.cs" />
     <Compile Include="Game\Entities\Units\UnitTool.cs" />
     <Compile Include="Game\GameData.Rewards.cs" />
     <Compile Include="Game\GameData.Sounds.cs" />


### PR DESCRIPTION
* Monsters now get hurt by spawning and moving Somaria Blocks.
* Somaria Block can no longer spawn and will despawn when colliding with
solid entities. TODO: Determine how to prevent spawning over Thwomp's
SoftCollisionBox.