### PR TITLE
Pickupable Entities, Spiny Beetle, & Mushroom tile

### DIFF
--- a/ZeldaOracle/ConscriptDesigner/Themes/ConscriptHighlighting.xshd
+++ b/ZeldaOracle/ConscriptDesigner/Themes/ConscriptHighlighting.xshd
@@ -261,6 +261,7 @@
       <Word>SPRITEINDEX</Word>
       <Word>SPRITELIST</Word>
       <Word>SPRITEOBJ</Word>
+      <Word>BREAKLAYER</Word>
       <Word>BREAKANIM</Word>
       <Word>BREAKSOUND</Word>
       <Word>MODEL</Word>

--- a/ZeldaOracle/Game/Common/Geometry/RangeF.cs
+++ b/ZeldaOracle/Game/Common/Geometry/RangeF.cs
@@ -106,6 +106,11 @@ namespace ZeldaOracle.Common.Geometry {
 		// Mutators
 		//-----------------------------------------------------------------------------
 
+		public void Set(float uniform) {
+			this.Min = uniform;
+			this.Max = uniform;
+		}
+
 		public void Set(float min, float max) {
 			this.Min = min;
 			this.Max = max;

--- a/ZeldaOracle/Game/Common/Geometry/RangeI.cs
+++ b/ZeldaOracle/Game/Common/Geometry/RangeI.cs
@@ -97,6 +97,11 @@ namespace ZeldaOracle.Common.Geometry {
 		// Mutators
 		//-----------------------------------------------------------------------------
 
+		public void Set(int uniform) {
+			this.Min = uniform;
+			this.Max = uniform;
+		}
+
 		public void Set(int min, int max) {
 			this.Min = min;
 			this.Max = max;

--- a/ZeldaOracle/Game/Common/Graphics/Unmapping.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Unmapping.cs
@@ -48,7 +48,7 @@ namespace ZeldaOracle.Common.Graphics {
 
 		/// <summary>Gets the hash code for the unmapped sprite lookup.</summary>
 		public override int GetHashCode() {
-			return base.GetHashCode();
+			return SpriteParts.GetHashCode();
 		}
 
 		/// <summary>Returns true if the object is an unmapped sprite lookup and equal.</summary>

--- a/ZeldaOracle/Game/Common/Scripts/CustomReaders/TileDataSR.cs
+++ b/ZeldaOracle/Game/Common/Scripts/CustomReaders/TileDataSR.cs
@@ -12,6 +12,7 @@ using ZeldaOracle.Common.Graphics.Sprites;
 using ZeldaOracle.Common.Scripting;
 using ZeldaOracle.Common.Scripts.Commands;
 using ZeldaOracle.Game;
+using ZeldaOracle.Game.Entities;
 using ZeldaOracle.Game.Entities.Monsters;
 using ZeldaOracle.Game.Tiles;
 using ZeldaOracle.Game.Tiles.ActionTiles;
@@ -363,6 +364,16 @@ namespace ZeldaOracle.Common.Scripts.CustomReaders {
 				if (!drawOffset.IsZero) {
 					tileData.SpriteAsObject = new OffsetSprite(tileData.Sprite, drawOffset);
 				}
+			});
+			//=====================================================================================
+			AddCommand("BREAKLAYER", (int) Modes.Tile,
+				"string layerName",
+			delegate (CommandParam parameters) {
+				string depthStr = parameters.GetString(0);
+				DepthLayer breakLayer;
+				if (!Enum.TryParse(depthStr, true, out breakLayer))
+					ThrowCommandParseError("Unknown DepthLayer '" + depthStr + "'!");
+				tileData.BreakLayer = breakLayer;
 			});
 			//=====================================================================================
 			AddCommand("BREAKANIM", (int) Modes.Tile,

--- a/ZeldaOracle/Game/Game/Control/RoomControl.cs
+++ b/ZeldaOracle/Game/Game/Control/RoomControl.cs
@@ -231,7 +231,7 @@ namespace ZeldaOracle.Game.Control {
 						for (int x = 0; x < size.X; x++) {
 							for (int y = 0; y < size.Y; y++) {
 								Effect effect = new Effect(GameData.ANIM_EFFECT_BLOCK_POOF,
-									DepthLayer.EffectSomariaBlockPoof);
+									DepthLayer.EffectBlockPoof);
 								Vector2F pos = (tile.Location + new Point2I(x, y) + Vector2F.Half) * GameSettings.TILE_SIZE;
 								SpawnEntity(effect, pos);
 							}

--- a/ZeldaOracle/Game/Game/Entities/Collectibles/Collectible.cs
+++ b/ZeldaOracle/Game/Game/Entities/Collectibles/Collectible.cs
@@ -10,7 +10,7 @@ namespace ZeldaOracle.Game.Entities {
 	public class Collectible : Entity {
 
 		protected int timer;
-		protected int pickupableDelay;
+		protected int collectibleDelay;
 		protected int aliveDuration;
 		protected int fadeDelay;
 		protected bool hasDuration;
@@ -37,7 +37,7 @@ namespace ZeldaOracle.Game.Entities {
 
 			aliveDuration	= GameSettings.COLLECTIBLE_ALIVE_DURATION;
 			fadeDelay		= GameSettings.COLLECTIBLE_FADE_DELAY;
-			pickupableDelay	= GameSettings.COLLECTIBLE_PICKUPABLE_DELAY;
+			collectibleDelay	= GameSettings.COLLECTIBLE_PICKUPABLE_DELAY;
 
 			isCollectibleWithItems = true;
 
@@ -80,7 +80,7 @@ namespace ZeldaOracle.Game.Entities {
 			}
 
 			// Check if colliding with the player.
-			if (physics.IsSoftMeetingEntity(GameControl.Player, 9) && IsPickupable)
+			if (physics.IsSoftMeetingEntity(GameControl.Player, 9) && IsCollectible)
 				Collect();
 		}
 
@@ -89,17 +89,17 @@ namespace ZeldaOracle.Game.Entities {
 		// Properties
 		//-----------------------------------------------------------------------------
 
-		public bool IsPickupable {
-			get { return (timer >= pickupableDelay); }
+		public bool IsCollectible {
+			get { return (timer >= collectibleDelay); }
 		}
 
 		public bool IsCollectibleWithItems {
 			get { return isCollectibleWithItems; }
 		}
 
-		public int PickupableDelay {
-			get { return pickupableDelay; }
-			set { pickupableDelay = value; }
+		public int CollectibleDelay {
+			get { return collectibleDelay; }
+			set { collectibleDelay = value; }
 		}
 
 		public bool HasDuration {

--- a/ZeldaOracle/Game/Game/Entities/DepthLayer.cs
+++ b/ZeldaOracle/Game/Game/Entities/DepthLayer.cs
@@ -63,7 +63,7 @@ namespace ZeldaOracle.Game.Entities {
 		EffectMagnetGloves,
 		EffectSprintDustParticle,
 		EffectCrackedFloorCrumble,
-		EffectSomariaBlockPoof,
+		EffectBlockPoof,
 		ProjectileCarriedTile,
 		ItemSeedShooter,
 

--- a/ZeldaOracle/Game/Game/Entities/Effects/EffectCreateSomariaBlock.cs
+++ b/ZeldaOracle/Game/Game/Entities/Effects/EffectCreateSomariaBlock.cs
@@ -26,7 +26,7 @@ namespace ZeldaOracle.Game.Entities.Effects {
 			this.position		= (tileLocation * GameSettings.TILE_SIZE) + new Vector2F(8, 8);
 			this.zPosition		= zPosition;
 			
-			Graphics.DepthLayer	= DepthLayer.EffectSomariaBlockPoof;
+			Graphics.DepthLayer	= DepthLayer.EffectBlockPoof;
 		}
 		
 
@@ -85,7 +85,7 @@ namespace ZeldaOracle.Game.Entities.Effects {
 			else {
 				// Spawn a poof effect.
 				RoomControl.SpawnEntity(
-					new Effect(GameData.ANIM_EFFECT_SOMARIA_BLOCK_DESTROY, DepthLayer.EffectSomariaBlockPoof),
+					new Effect(GameData.ANIM_EFFECT_SOMARIA_BLOCK_DESTROY, DepthLayer.EffectBlockPoof),
 					position, zPosition);
 			}
 		}

--- a/ZeldaOracle/Game/Game/Entities/Entity.cs
+++ b/ZeldaOracle/Game/Game/Entities/Entity.cs
@@ -26,6 +26,9 @@ namespace ZeldaOracle.Game.Entities {
 		protected int				actionAlignDistance; // How many pixels off of alignment to interact with the entity (based on center positions).
 		protected Rectangle2F		buttonActionCollisionBox; // Collision box that for button actions
 		protected Sound				soundBounce;
+		protected bool              isGrabbable;
+		protected bool              isPickupable;
+		protected Vector2F          carriedDrawOffset;
 
 		protected PhysicsComponent	physics;
 		protected GraphicsComponent	graphics;
@@ -89,6 +92,11 @@ namespace ZeldaOracle.Game.Entities {
 		/// <summary>Called every step to draw the entity.</summary>
 		public virtual void Draw(RoomGraphics g) {
 			graphics.Draw(g);
+		}
+
+		/// <summary>Called every step to draw the entity.</summary>
+		public virtual void Draw(RoomGraphics g, DepthLayer depthLayer) {
+			graphics.Draw(g, depthLayer);
 		}
 
 		/// <summary>Called when the entity enters the room. FIXME: this is never
@@ -157,9 +165,23 @@ namespace ZeldaOracle.Game.Entities {
 			}
 		}
 
-		/// <summary>Special update method for when the entity is being carried.
-		/// </summary>
-		public virtual void UpdateCarrying() {}
+		/// <summary>Called when the entity is picked up.</summary>
+		public virtual void OnPickup() { }
+
+		/// <summary>Called when the entity has been picked up and is now being carried.</summary>
+		public virtual void OnCarry() { }
+
+		/// <summary>Called when the carried entity is thrown.</summary>
+		public virtual void OnThrow() { }
+
+		/// <summary>Called when the carried entity is dropped.</summary>
+		public virtual void OnDrop() { }
+
+		/// <summary>Updates the entity while being carried or picked up.</summary>
+		public virtual void UpdateCarrying(bool isPickingUp) { }
+
+		/// <summary>Draws the entity while being carried or picked up.</summary>
+		public virtual void DrawCarrying(RoomGraphics g, bool isPickingUp) { }
 
 		/// <summary>Called immediately after the entity is destroyed.</summary>
 		public virtual void OnDestroy() {}
@@ -238,6 +260,29 @@ namespace ZeldaOracle.Game.Entities {
 				return aBox.LeftRight.Intersects(bBox.LeftRight);
 			else
 				return aBox.TopBottom.Intersects(bBox.TopBottom);
+		}
+
+
+		//-----------------------------------------------------------------------------
+		// Virtual Properties
+		//-----------------------------------------------------------------------------
+
+		/// <summary>Gets or sets if the entity can currently be grabbed.</summary>
+		public bool IsGrabbable {
+			get { return isGrabbable; }
+			set { isGrabbable = value; }
+		}
+
+		/// <summary>Gets or sets if the entity can currently be picked up.</summary>
+		public bool IsPickupable {
+			get { return isPickupable; }
+			set { isPickupable = value; }
+		}
+
+		/// <summary>Gets or sets the extra draw offset applied while carring the entity.</summary>
+		public Vector2F CarriedDrawOffset {
+			get { return carriedDrawOffset; }
+			set { carriedDrawOffset = value; }
 		}
 
 

--- a/ZeldaOracle/Game/Game/Entities/EntityTracker.cs
+++ b/ZeldaOracle/Game/Game/Entities/EntityTracker.cs
@@ -44,6 +44,12 @@ namespace ZeldaOracle.Game.Entities {
 			return false;
 		}
 
+		public void ClearEntities() {
+			for (int i = 0; i < entities.Length; i++) {
+				entities[i] = null;
+			}
+		}
+
 		// Return true if a non-null entity is considered dead/destroyed.
 		private bool IsEntityDead(Entity entity) {
 			return (entity.IsDestroyed || !entity.IsInRoom);

--- a/ZeldaOracle/Game/Game/Entities/GraphicsComponent.cs
+++ b/ZeldaOracle/Game/Game/Entities/GraphicsComponent.cs
@@ -87,9 +87,17 @@ namespace ZeldaOracle.Game.Entities
 			if (palette == null)
 				palette = Entity.RoomControl.Zone.Palette;
 
+			ColorDefinitions finalColorDefinitions = colorDefinitions;
+
+			// Change the color if hurting.
+			if (isHurting && entity.GameControl.RoomTicks % 8 >= 4) {
+				finalColorDefinitions = ColorDefinitions.All("hurt");
+			}
+
 			Graphics2D g2d = new Graphics2D(Resources.SpriteBatch);
 			unmappedSprite = Unmapping.UnmapSprite(g2d, animationPlayer.SpriteOrSubStrip,
-				new SpriteSettings(colorDefinitions, animationPlayer.PlaybackTime),
+				new SpriteSettings(Entity.RoomControl.Zone.StyleDefinitions,
+					colorDefinitions, animationPlayer.PlaybackTime),
 				palette, Entity.RoomControl.EntityPalette);
 		}
 
@@ -159,19 +167,7 @@ namespace ZeldaOracle.Game.Entities
 			}
 
 			if (unmapped) {
-				ColorDefinitions finalColorDefinitions = colorDefinitions;
-
-				// Change the color if hurting.
-				if (isHurting && entity.GameControl.RoomTicks % 8 >= 4) {
-					finalColorDefinitions = ColorDefinitions.All("hurt");
-				}
-
-				Palette palette = Entity.RoomControl.TilePaletteOverride ?? unmappedPalette;
-
-				Graphics2D g2d = new Graphics2D(Resources.SpriteBatch);
-				unmappedSprite = Unmapping.UnmapSprite(g2d, animationPlayer.SpriteOrSubStrip,
-					new SpriteSettings(finalColorDefinitions, animationPlayer.PlaybackTime),
-					palette, Entity.RoomControl.EntityPalette);
+				CreateUnmappedSprite();
 			}
 		}
 

--- a/ZeldaOracle/Game/Game/Entities/Monsters/BasicMonster.cs
+++ b/ZeldaOracle/Game/Game/Entities/Monsters/BasicMonster.cs
@@ -270,7 +270,7 @@ namespace ZeldaOracle.Game.Entities.Monsters {
 
 		protected void StartCharging(int chargeDirection) {
 			direction	= chargeDirection;
-			moveAngle	= direction * 4 / numMoveAngles;
+			moveAngle	= direction * numMoveAngles / 4;
 			isCharging	= true;
 			chargeCooldownTimer = chargeCooldown;
 
@@ -279,9 +279,9 @@ namespace ZeldaOracle.Game.Entities.Monsters {
 			}
 		}
 
-		protected void EndCharging() {
+		protected void StopCharging() {
 			isCharging = false;
-			speed = GMath.Min(speed, moveSpeed);
+			StartMoving();
 		}
 
 		protected void UpdateChargingState() {
@@ -289,17 +289,25 @@ namespace ZeldaOracle.Game.Entities.Monsters {
 
 			Physics.Velocity = GetMovementVelocity(moveAngle, speed);
 
+			if (avoidHazardTiles) {
+				// Avoid moving into a hazardous tile
+				foreach (Tile tile in Physics.GetTilesMeeting(
+					position + physics.Velocity * 1.1f, CollisionBoxType.Hard)) {
+					if (tile.IsHoleWaterOrLava) {
+						StopCharging();
+						return;
+					}
+				}
+			}
 			if (chargeType == ChargeType.ChargeForDuration) {
 				if (moveTimer <= 0) {
-					EndCharging();
+					StopCharging();
 					return;
 				}
 			}
-			else {
-				if (Physics.IsColliding) {
-					EndCharging();
-					return;
-				}
+			if (Physics.IsColliding) {
+				StopCharging();
+				return;
 			}
 
 			moveTimer--;

--- a/ZeldaOracle/Game/Game/Entities/Monsters/Monster.cs
+++ b/ZeldaOracle/Game/Game/Entities/Monsters/Monster.cs
@@ -129,7 +129,7 @@ namespace ZeldaOracle.Game.Entities.Monsters {
 			SetReaction(InteractionType.Shield,			SenderReactions.Bump,		Reactions.Bump);
 			SetReaction(InteractionType.Shovel,			Reactions.Bump);
 			SetReaction(InteractionType.Parry,			Reactions.Parry);
-			SetReaction(InteractionType.Pickup,			Reactions.None);
+			SetReaction(InteractionType.Bracelet,			Reactions.None);
 			// Seed interations
 			SetReaction(InteractionType.EmberSeed,		SenderReactions.Intercept);
 			SetReaction(InteractionType.ScentSeed,		SenderReactions.Intercept,	Reactions.SilentDamage);

--- a/ZeldaOracle/Game/Game/Entities/Monsters/MonsterReactions.cs
+++ b/ZeldaOracle/Game/Game/Entities/Monsters/MonsterReactions.cs
@@ -49,9 +49,9 @@ namespace ZeldaOracle.Game.Entities.Monsters {
 		/// <summary>TODO.
 		/// <para/>Default = Reactions.None</summary>
 		Parry,
-		/// <summary>Attempt to use the bracelet to pickup.
+		/// <summary>Attempt to use the bracelet to pickup or grab.
 		/// <para/>Default = Reactions.None</summary>
-		Pickup,
+		Bracelet,
 		
 		//-----------------------------------------------------------------------------
 		// Seed Interactions
@@ -151,16 +151,17 @@ namespace ZeldaOracle.Game.Entities.Monsters {
 	//-----------------------------------------------------------------------------
 	
 	public class InteractionArgs : EventArgs {
-        public Vector2F ContactPoint { get; set; }
+		public Vector2F ContactPoint { get; set; }
 	}
 
 	public class WeaponInteractionEventArgs : EventArgs {
-        public ItemWeapon Weapon { get; set; }
+		public ItemWeapon Weapon { get; set; }
+		public UnitTool Tool { get; set; }
 	}
 	
 	public class ParryInteractionArgs : InteractionArgs {
-        public UnitTool SenderTool { get; set; }
-        public UnitTool MonsterTool { get; set; }
+		public UnitTool SenderTool { get; set; }
+		public UnitTool MonsterTool { get; set; }
 	}
 
 

--- a/ZeldaOracle/Game/Game/Entities/Monsters/MonsterSpinyBeetle.cs
+++ b/ZeldaOracle/Game/Game/Entities/Monsters/MonsterSpinyBeetle.cs
@@ -1,0 +1,427 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ZeldaOracle.Common.Audio;
+using ZeldaOracle.Common.Geometry;
+using ZeldaOracle.Common.Scripting;
+using ZeldaOracle.Game.Entities.Effects;
+using ZeldaOracle.Game.Entities.Projectiles.MonsterProjectiles;
+using ZeldaOracle.Game.Entities.Projectiles.PlayerProjectiles;
+using ZeldaOracle.Game.Tiles;
+
+namespace ZeldaOracle.Game.Entities.Monsters {
+	public class MonsterSpinyBeetle : Monster {
+
+		//-------------------------------------------------------------------------
+		// Constants
+		//-------------------------------------------------------------------------
+
+		private static readonly Rectangle2F DEFAULT_BOX			= new Rectangle2I(-5, -9, 10, 10);
+		//private static readonly Rectangle2F COVERED_SOFT_BOX	= new Rectangle2I(-7, -13, 14, 14);
+		//private static readonly Rectangle2F UNCOVERED_SOFT_BOX	= new Rectangle2I(-6, -11, 12, 11);
+		//private static readonly Rectangle2F PLAYER_SOFT_BOX		= new Rectangle2I(-4, -11, 8, 6);
+
+		private static readonly Rectangle2F[] CHARGE_BOXES = {
+			new Rectangle2I(-5, -9, 13, 10),
+			new Rectangle2I(-5, -14, 10, 15),
+			new Rectangle2I(-8, -9, 13, 10),
+			new Rectangle2I(-5, -9, 10, 11)
+		};
+
+
+		//-------------------------------------------------------------------------
+		// Members
+		//-------------------------------------------------------------------------
+
+		private Tile coverTile;
+		private CarriedTile carriedTile;
+		
+		private bool covered;
+		private bool revealed;
+		private bool uncoverPause;
+
+		private float moveSpeed;
+		private int moveAngle;
+		private int moveDuration;
+		private int moveTimer;
+
+		private int chargeDuration;
+		private int chargeCooldown;
+
+
+		//-------------------------------------------------------------------------
+		// Constructor
+		//-------------------------------------------------------------------------
+
+		public MonsterSpinyBeetle() {
+			MaxHealth		= 1;
+			ContactDamage	= 2;
+			Color           = MonsterColor.Red;
+			
+			Physics.CollisionBox		= DEFAULT_BOX;
+			Physics.SoftCollisionBox	= new Rectangle2I(-4, -11, 8, 6);
+			Physics.BraceletCollisionBox	= new Rectangle2I(-6, -12, 12, 12);
+
+			// TODO: Bigger collision box for cover
+			
+			syncAnimationWithDirection	= false;
+			orientationStyle			= OrientationStyle.None;
+			
+			covered				= true;
+			revealed			= false;
+			uncoverPause		= false;
+
+			moveSpeed			= 0.875f;
+			moveDuration		= 40;
+			moveTimer           = 0;
+			
+			chargeDuration		= (int) GMath.Ceiling(GameSettings.TILE_SIZE * 3 / moveSpeed);
+			chargeCooldown      = 30;
+		}
+
+		private void SetCoveredInteractions() {
+			// Weapon interations
+
+			int swordLevel = -1;
+			if (GameControl.Inventory.ItemExists("item_sword"))
+				swordLevel = GameControl.Inventory.GetItem("item_sword").Level;
+			int cuttableLevel = CoverProperties.GetInteger("cuttable_sword_level");
+			if (CoverFlags.HasFlag(TileFlags.Cuttable) && swordLevel >= cuttableLevel) {
+				SetReaction(InteractionType.Sword,			SenderReactions.Intercept,	Reactions.DamageByLevel(1, 2, 3), BreakCover);
+				SetReaction(InteractionType.SwordSpin,		Reactions.Damage2,			BreakCover);
+				SetReaction(InteractionType.BiggoronSword,	Reactions.Damage3,			BreakCover);
+				SetReaction(InteractionType.SwordBeam,		SenderReactions.Destroy,	Reactions.Damage, BreakCover);
+				SetReaction(InteractionType.ThrownObject,	Reactions.Damage);
+			}
+			else {
+				SetReaction(InteractionType.Sword,			Reactions.ClingEffect);
+				SetReaction(InteractionType.SwordSpin,		Reactions.ClingEffect);
+				SetReaction(InteractionType.BiggoronSword,	Reactions.ClingEffect);
+				SetReaction(InteractionType.SwordBeam,		SenderReactions.Intercept);
+				SetReaction(InteractionType.ThrownObject,	Reactions.None);
+			}
+
+			int boomerangLevel = -1;
+			if (GameControl.Inventory.ItemExists("item_boomerang"))
+				boomerangLevel = GameControl.Inventory.GetItem("item_boomerang").Level;
+			if (CoverFlags.HasFlag(TileFlags.Boomerangable) && boomerangLevel >= Items.Item.Level2) {
+				SetReaction(InteractionType.Boomerang,		SenderReactions.Intercept,	Reactions.Stun, BreakCover);
+			}
+			else {
+				SetReaction(InteractionType.Boomerang,		SenderReactions.Intercept);
+			}
+
+			if (CoverFlags.HasFlag(TileFlags.Burnable)) {
+				SetReaction(InteractionType.Fire,			Reactions.Burn);
+			}
+			else {
+				// TODO: Flames need to go out quickly
+				SetReaction(InteractionType.Fire,			SenderReactions.Intercept);
+			}
+
+			if (CoverFlags.HasFlag(TileFlags.Bombable)) {
+				SetReaction(InteractionType.BombExplosion,	Reactions.Damage, BreakCover);
+			}
+			else {
+				SetReaction(InteractionType.BombExplosion,	Reactions.None);
+			}
+
+			SetReaction(InteractionType.Shield,			SenderReactions.Bump,		Reactions.Bump);
+			SetReaction(InteractionType.Shovel,			Reactions.Bump);
+			SetReaction(InteractionType.Parry,			Reactions.Parry);
+			SetReaction(InteractionType.Bracelet,			PickupInteraction);
+			// Seed interations
+			SetReaction(InteractionType.EmberSeed,		SenderReactions.Intercept);
+			SetReaction(InteractionType.ScentSeed,		SenderReactions.Intercept);
+			SetReaction(InteractionType.PegasusSeed,	SenderReactions.Intercept);
+			SetReaction(InteractionType.GaleSeed,		SenderReactions.Intercept);
+			SetReaction(InteractionType.MysterySeed,	Reactions.MysterySeed);
+			// Projectile interations
+			SetReaction(InteractionType.Arrow,			SenderReactions.Intercept);
+			SetReaction(InteractionType.RodFire,		SenderReactions.Intercept);
+			SetReaction(InteractionType.SwitchHook,		SwitchHookInteraction);
+			// Environment interations
+			SetReaction(InteractionType.Gale,			SenderReactions.Intercept);
+			SetReaction(InteractionType.MineCart,		Reactions.SoftKill);
+			SetReaction(InteractionType.Block,			Reactions.None);
+		}
+
+
+		//-------------------------------------------------------------------------
+		// Override Events
+		//-------------------------------------------------------------------------
+		
+		public override void Initialize() {
+			base.Initialize();
+
+			TileData coverTileData = Properties.GetResource<TileData>("cover_tile");
+			coverTile = Tile.CreateTile(coverTileData);
+			coverTile.Initialize(RoomControl);
+			carriedTile = new CarriedTile(coverTile);
+			carriedTile.Initialize(RoomControl);
+
+			SetCoveredInteractions();
+			Graphics.PlayAnimation(GameData.ANIM_MONSTER_SPINY_BEETLE);
+		}
+
+		public override void OnHurt(DamageInfo damage) {
+			if (covered)
+				Uncover(true);
+			base.OnHurt(damage);
+		}
+
+		public override void OnTouchPlayer(Entity sender, EventArgs args) {
+			if (revealed || !covered)
+				base.OnTouchPlayer(sender, args);
+		}
+
+		public override void Draw(RoomGraphics g) {
+			if (revealed || !covered) {
+				base.Draw(g);
+			}
+			if (covered) {
+				carriedTile.Position = Position + Graphics.DrawOffset -
+					carriedTile.Graphics.DrawOffset;
+				carriedTile.ZPosition = ZPosition;
+				if (revealed)
+					carriedTile.ZPosition += 4;
+				carriedTile.Draw(g, DepthLayer.PlayerAndNPCs);
+			}
+		}
+
+
+		//-------------------------------------------------------------------------
+		// Reactions
+		//-------------------------------------------------------------------------
+
+		private void SwitchHookInteraction(Monster monster, Entity sender, EventArgs args) {
+			SwitchHookProjectile hook = sender as SwitchHookProjectile;
+			carriedTile.Position = Center + new Vector2F(0, 4);
+			if (revealed)
+				carriedTile.ZPosition = 4;
+			// Prevent the spawned carried tile from hurting the monster.
+			carriedTile.DisablePhysics();
+			// Spawn the entity so it draws during the pause before switching.
+			RoomControl.SpawnEntity(carriedTile);
+			hook.SwitchWithEntity(carriedTile);
+			Uncover(false);
+		}
+
+		private void PickupInteraction(Monster monster, Entity sender, EventArgs args) {
+			RoomControl.Player.CarryState.SetCarryObject(coverTile);
+			RoomControl.Player.BeginWeaponState(RoomControl.Player.CarryState);
+			Uncover(false);
+		}
+
+		private void BreakCover(Monster monster, Entity sender, EventArgs args) {
+			Uncover(true);
+		}
+
+		private void BurnCover(Monster monster, Entity sender, EventArgs args) {
+			// TODO: Detach and burn cover tile
+			// (Monster keeps charging (most likely untill burned up))
+			BreakCover(monster, sender, args);
+		}
+
+
+		//-------------------------------------------------------------------------
+		// AI
+		//-------------------------------------------------------------------------
+
+		public override void UpdateAI() {
+			if (covered) {
+				carriedTile.UpdateGraphics();
+				if (!revealed)
+					UpdateTargetState();
+				else
+					UpdateChargeState();
+			}
+			else if (uncoverPause) {
+				// Pause after being uncovered
+				moveTimer--;
+				if (moveTimer == 0)
+					uncoverPause = false;
+			}
+			else {
+				UpdateMoveState();
+			}
+		}
+		
+		private void UpdateChargeState() {
+			if (moveTimer == 0) {
+				StopCharging();
+				return;
+			}
+
+			Vector2F velocity = Angles.ToVector(moveAngle) * moveSpeed;
+			int direction = moveAngle / 2;
+			int axis = Directions.ToAxis(direction);
+
+			if (moveTimer == 1) {
+				if (direction == Directions.Left || direction == Directions.Up) {
+					velocity = Vector2F.FromIndex(axis, GMath.Floor(
+						Position[axis]) - position[axis]);
+				}
+				else {
+					velocity = Vector2F.FromIndex(axis, GMath.Ceiling(
+						Position[axis]) - position[axis]);
+				}
+			}
+
+			Physics.Velocity = velocity;
+
+			if (Physics.IsColliding) {
+				StopCharging();
+				return;
+			}
+			
+			// Avoid moving into a hazardous or solid tiles
+			foreach (Tile tile in Physics.GetTilesMeeting(
+				Position + Physics.Velocity, CollisionBoxType.Hard))
+			{
+				if (tile.IsHoleWaterOrLava) {
+					if (direction == Directions.Left || direction == Directions.Up) {
+						position[axis] = tile.Bounds.BottomRight[axis] -
+							Graphics.DrawOffset[axis];
+					}
+					else {
+						position[axis] = tile.Position[axis] -
+							GameSettings.TILE_SIZE - Graphics.DrawOffset[axis];
+					}
+					StopCharging();
+					return;
+				}
+			}
+
+			moveTimer--;
+		}
+
+		private void StartCharging(int direction) {
+			revealed = true;
+			moveTimer = chargeDuration;
+			moveAngle = Directions.ToAngle(direction);
+			Physics.CollisionBox = CHARGE_BOXES[direction];
+			
+			// Don't check for future collisions and force a popup if player is hit.
+			// Otherwise, if future collision is detected, don't popup.
+			if (Physics.IsMeetingEntity(RoomControl.Player, CollisionBoxType.Soft)) {
+				TriggerInteraction(InteractionType.PlayerContact, RoomControl.Player);
+				return;
+			}
+			Vector2F nextVelocity = Angles.ToVector(moveAngle) * moveSpeed;
+
+			// Avoid moving into a hazardous or solid tiles
+			foreach (Tile tile in Physics.GetTilesMeeting(
+				Position + nextVelocity, CollisionBoxType.Hard))
+			{
+				if (tile.IsHoleWaterOrLava || tile.IsSolid) {
+					StopCharging();
+					return;
+				}
+			}
+			if (Physics.IsPlaceMeetingRoomEdge(Position + nextVelocity)) {
+				StopCharging();
+				return;
+			}
+		}
+
+		private void StopCharging() {
+			revealed = false;
+			moveTimer = chargeCooldown;
+			Physics.Velocity = Vector2F.Zero;
+			Physics.CollisionBox = DEFAULT_BOX;
+		}
+
+		private void UpdateMoveState() {
+			// Change direction timer
+			if (moveTimer == 0) {
+				moveTimer = moveDuration;
+				moveAngle = GRandom.NextInt(Angles.AngleCount);
+			}
+
+
+			Vector2F velocity = Angles.ToVector(moveAngle) * moveSpeed;
+			
+			// Avoid moving into a hazardous tile
+			foreach (Tile tile in Physics.GetTilesMeeting(
+				Position + velocity, CollisionBoxType.Hard))
+			{
+				if (tile.IsHoleWaterOrLava) {
+					int direction = Directions.NearestFromVector(tile.Center - Physics.PositionedCollisionBox.Center);
+					int axis = Directions.ToAxis(direction);
+					velocity[axis] = 0f;
+					if (Physics.IsPlaceMeetingTile(Position + velocity, tile)) {
+						velocity = Vector2F.Zero;
+						break;
+					}
+				}
+			}
+
+			Physics.Velocity = velocity;
+
+			moveTimer--;
+		}
+
+		private void UpdateTargetState() {
+			// Charge cooldown
+			if (moveTimer > 0) {
+				moveTimer--;
+				return;
+			}
+			Physics.Velocity = Vector2F.Zero;
+			Vector2F vectorToPlayer = RoomControl.Player.Center - Center;
+			int direction = Directions.NearestFromVector(vectorToPlayer);
+			if (direction == Directions.Up) {
+				Rectangle2F box = new Rectangle2F(-8, -8, 16, 8) + Position;
+				if (RoomControl.Player.Physics.
+					PositionedSoftCollisionBox.Intersects(box))
+					StartCharging(direction);
+			}
+			else if (direction == Directions.Down) {
+				RangeF range = new RangeF(Position.X - 8, Position.X + 8);
+				if (RoomControl.Player.Physics.PositionedSoftCollisionBox.
+					LeftRight.Intersects(range))
+					StartCharging(direction);
+			}
+			else {
+				RangeF range = new RangeF(Position.Y - 12, Position.Y + 1);
+				if (RoomControl.Player.Physics.PositionedSoftCollisionBox.
+					TopBottom.Intersects(range))
+					StartCharging(direction);
+			}
+		}
+
+		public void Uncover(bool shouldBreak) {
+			StopCharging();
+			covered = false;
+			SetDefaultReactions();
+			Physics.SoftCollisionBox    = new Rectangle2I(-6, -11, 12, 11);
+			if (shouldBreak) {
+				if (coverTile.BreakAnimation != null) {
+					Effect breakEffect = new Effect(coverTile.BreakAnimation, coverTile.BreakLayer, true);
+					RoomControl.SpawnEntity(breakEffect, Center);
+				}
+				if (coverTile.BreakSound != null)
+					AudioSystem.PlaySound(coverTile.BreakSound);
+			}
+			uncoverPause = true;
+			moveTimer = 64;
+			Physics.Velocity = Vector2F.Zero;
+		}
+
+
+		//-------------------------------------------------------------------------
+		// Internal Properties
+		//-------------------------------------------------------------------------
+
+		private TileFlags CoverFlags {
+			get { return coverTile.Flags; }
+		}
+
+		private Properties CoverProperties {
+			get { return coverTile.Properties; }
+		}
+	}
+}

--- a/ZeldaOracle/Game/Game/Entities/PhysicsComponent.cs
+++ b/ZeldaOracle/Game/Game/Entities/PhysicsComponent.cs
@@ -71,7 +71,8 @@ namespace ZeldaOracle.Game.Entities {
 		
 		// Collision settings
 		private Rectangle2F				collisionBox;		// The "hard" collision box, used to collide with solid entities/tiles.
-		private Rectangle2F				softCollisionBox;	// The "soft" collision box, used to collide with items, monsters, room edges, etc.
+		private Rectangle2F				softCollisionBox;   // The "soft" collision box, used to collide with items, monsters, room edges, etc.
+		private Rectangle2F				braceletCollisionBox;
 		private TileCollisionCondition	customTileIsSolidCondition;
 		private TileCollisionCondition	customTileIsNotSolidCondition;
 		private CollisionBoxType		roomEdgeCollisionBoxType;
@@ -113,6 +114,7 @@ namespace ZeldaOracle.Game.Entities {
 			this.maxFallSpeed		= GameSettings.DEFAULT_MAX_FALL_SPEED;
 			this.collisionBox		= new Rectangle2F(-1, -1, 2, 2);
 			this.softCollisionBox	= new Rectangle2F(-1, -1, 2, 2);
+			this.braceletCollisionBox	= new Rectangle2F(-1, -1, 2, 2);
 			this.topTile			= null;
 			this.topTilePointOffset	= Vector2F.Zero;
 			this.isColliding		= false;
@@ -369,6 +371,15 @@ namespace ZeldaOracle.Game.Entities {
 			collisionBox.Point += entity.Position;
 			if (GMath.Abs(entity.ZPosition - other.ZPosition) < maxZDistance)
 				return collisionBox.Intersects(other.Physics.PositionedSoftCollisionBox);
+			return false;
+		}
+
+		public bool IsBraceletMeetingEntity(Entity other, Rectangle2F collisionBox,
+			int maxZDistance = 10)
+		{
+			collisionBox.Point += entity.Position;
+			if (GMath.Abs(entity.ZPosition - other.ZPosition) < maxZDistance)
+				return collisionBox.Intersects(other.Physics.PositionedBraceletCollisionBox);
 			return false;
 		}
 
@@ -744,6 +755,11 @@ namespace ZeldaOracle.Game.Entities {
 			set { softCollisionBox = value; }
 		}
 
+		public Rectangle2F BraceletCollisionBox {
+			get { return braceletCollisionBox; }
+			set { braceletCollisionBox = value; }
+		}
+
 		/// <summary>The "Hard" collision box translated to the entity's current
 		/// position.</summary>
 		public Rectangle2F PositionedCollisionBox {
@@ -754,6 +770,10 @@ namespace ZeldaOracle.Game.Entities {
 		/// position.</summary>
 		public Rectangle2F PositionedSoftCollisionBox {
 			get { return Rectangle2F.Translate(softCollisionBox, entity.Position); }
+		}
+
+		public Rectangle2F PositionedBraceletCollisionBox {
+			get { return Rectangle2F.Translate(braceletCollisionBox, entity.Position); }
 		}
 
 		public TileCollisionCondition CustomTileIsSolidCondition {

--- a/ZeldaOracle/Game/Game/Entities/Players/ControlStates/PlayerSwitchHookSwitchState.cs
+++ b/ZeldaOracle/Game/Game/Entities/Players/ControlStates/PlayerSwitchHookSwitchState.cs
@@ -124,7 +124,8 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 				}
 
 				// Spawn drops as the tile is picked up
-				hookedTile.SpawnDrop();
+				if (hookedTile.StaysOnSwitch)
+					hookedTile.SpawnDrop();
 			}
 
 			hookedEntity.RemoveFromRoom();
@@ -178,6 +179,7 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 					}
 					else {
 						player.RoomControl.SpawnEntity(hookedEntity);
+						hookedEntity.OnLand();
 					}
 
 					End();

--- a/ZeldaOracle/Game/Game/Entities/Players/Tools/PlayerToolShield.cs
+++ b/ZeldaOracle/Game/Game/Entities/Players/Tools/PlayerToolShield.cs
@@ -64,7 +64,8 @@ namespace ZeldaOracle.Game.Entities.Players.Tools {
 
 		public override void OnHitMonster(Monster monster) {
 			monster.TriggerInteraction(InteractionType.Shield, unit, new WeaponInteractionEventArgs() {
-				Weapon = itemShield
+				Weapon = itemShield,
+				Tool = this
 			});
 		}
 

--- a/ZeldaOracle/Game/Game/Entities/Players/Tools/PlayerToolSword.cs
+++ b/ZeldaOracle/Game/Game/Entities/Players/Tools/PlayerToolSword.cs
@@ -39,7 +39,7 @@ namespace ZeldaOracle.Game.Entities.Players.Tools {
 			// Collect collectible entities.
 			if (entity is Collectible) {
 				Collectible collectible = (Collectible) entity;
-				if (collectible.IsPickupable && collectible.IsCollectibleWithItems)
+				if (collectible.IsCollectible && collectible.IsCollectibleWithItems)
 					collectible.Collect();
 			}
 		}
@@ -62,7 +62,8 @@ namespace ZeldaOracle.Game.Entities.Players.Tools {
 
 			// Trigger the monster's sword reaction.
 			monster.TriggerInteraction(interactionType, unit, new WeaponInteractionEventArgs() {
-				Weapon = itemSword
+				Weapon = itemSword,
+				Tool = this
 			});
 
 			// Stab if holding sword.

--- a/ZeldaOracle/Game/Game/Entities/Players/WeaponStates/PlayerCarryState.cs
+++ b/ZeldaOracle/Game/Game/Entities/Players/WeaponStates/PlayerCarryState.cs
@@ -25,7 +25,7 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 		private int objectZOffset;
 		private bool isObjectDropped;
 
-		private Entity carryObject;
+		private Entity carryEntity;
 		private int throwDuration; // How many ticks the player waits when throwing.
 		private int pickupFrame1Duration;
 		private int pickupFrame2Duration;
@@ -39,71 +39,64 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 		public PlayerCarryState() {
 		}
 
-		public PlayerCarryState(Entity carryObject) {
-			this.carryObject			= carryObject;
-			this.throwDuration			= 8;
-			this.pickupFrame1Duration	= 4;
-			this.pickupFrame2Duration	= 4;
-		}
 
-		public PlayerCarryState(Tile carryTile) {
-			this.carryObject			= new CarriedTile(carryTile);
-			this.throwDuration			= 2;
-			this.pickupFrame1Duration	= 6;
-			this.pickupFrame2Duration	= 4;
-		}
-
-		
 		//-----------------------------------------------------------------------------
 		// Internal methods.
 		//-----------------------------------------------------------------------------
-		
-		public void SetCarryObject(object carryObject) {
-			if (carryObject is Tile) {
-				Tile carryTile = (Tile) carryObject;
-				this.carryObject			= new CarriedTile(carryTile);
-				this.throwDuration			= 2;
-				this.pickupFrame1Duration	= 6;
-				this.pickupFrame2Duration	= 4;
-			}
-			else if (carryObject is Entity) {
-				this.carryObject			= (Entity) carryObject;
-				this.throwDuration			= 8;
-				this.pickupFrame1Duration	= 4;
-				this.pickupFrame2Duration	= 4;
-			}
+
+		public void SetCarryObject(Tile tile) {
+			this.carryEntity            = new CarriedTile(tile);
+			this.throwDuration          = 2;
+			this.pickupFrame1Duration   = 6;
+			this.pickupFrame2Duration   = 4;
+		}
+
+		public void SetCarryObject(Entity entity) {
+			this.carryEntity            = entity;
+			this.throwDuration          = 8;
+			this.pickupFrame1Duration   = 4;
+			this.pickupFrame2Duration   = 4;
 		}
 
 		public void DropObject(bool enterBusyState = true, bool playSound = true) {
 			PlayerAnimations.Default = null;
 
-			if (carryObject != null && carryObject.IsAlive) {
-				isObjectDropped = true;
-				player.RoomControl.SpawnEntity(carryObject, player.Position, 16);
-				if (enterBusyState) {
-					player.Graphics.PlayAnimation(player.Animations.Throw);
-					StateMachine.BeginState(new PlayerBusyState(
-						throwDuration, player.StateParameters.PlayerAnimations.Throw));
-				}
-				else if (isPickingUp) {
-					StateParameters.ProhibitMovementControl = false;
-					isPickingUp = false;
-				}
-				if (playSound)
-					AudioSystem.PlaySound(GameData.SOUND_PLAYER_THROW);
+			if (carryEntity != null && carryEntity.IsAlive) {
+				DropObjectBase(enterBusyState, playSound);
+				carryEntity.OnDrop();
 			}
 		}
 
+		private void DropObjectBase(bool enterBusyState = true, bool playSound = true) {
+			PlayerAnimations.Default = null;
+			
+			isObjectDropped = true;
+			player.RoomControl.SpawnEntity(carryEntity, player.Position, 16);
+			if (enterBusyState) {
+				player.Graphics.PlayAnimation(player.Animations.Throw);
+				StateMachine.BeginState(new PlayerBusyState(
+					throwDuration, player.StateParameters.PlayerAnimations.Throw));
+			}
+			else if (isPickingUp) {
+				StateParameters.ProhibitMovementControl = false;
+				isPickingUp = false;
+			}
+			if (playSound)
+				AudioSystem.PlaySound(GameData.SOUND_PLAYER_THROW);
+		}
+
 		public void ThrowObject(bool enterBusyState = true, bool playSound = true) {
-			if (carryObject != null && carryObject.IsAlive) {
-				carryObject.Physics.ZVelocity = 1.0f;
-				carryObject.Physics.Velocity = Directions.ToVector(player.MoveDirection) * 1.5f;
-				DropObject(enterBusyState, playSound);
+			if (carryEntity != null && carryEntity.IsAlive) {
+				carryEntity.Physics.ZVelocity = 1.0f;
+				carryEntity.Physics.Velocity = Directions.ToVector(player.MoveDirection) * 1.5f;
+				DropObjectBase(enterBusyState, playSound);
+				carryEntity.OnThrow();
 			}
 		}
 
 		public void ReleaseObject(bool enterBusyState = true, bool playSound = true) {
-			if (player.Movement.IsMoving)
+			// Prevent throwing during pickup phase
+			if (player.Movement.IsMoving && !isPickingUp)
 				ThrowObject(enterBusyState, playSound);
 			else
 				DropObject(enterBusyState, playSound);
@@ -111,7 +104,7 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 
 		public void DestroyObject() {
 			isObjectDropped = true;
-			carryObject.Destroy();
+			carryEntity.Destroy();
 		}
 
 
@@ -120,13 +113,13 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 		//-----------------------------------------------------------------------------
 		
 		public override void OnBegin(PlayerState previousState) {
-			carryObject.Initialize(player.RoomControl);
+			carryEntity.Initialize(player.RoomControl);
 
 			isObjectDropped = false;
 			
 			objectZOffset = 0;
-			if (carryObject is CarriedTile)
-				objectDrawOffset.Y -= 2;
+			//if (carryEntity is CarriedTile)
+			//	objectDrawOffset.Y -= 2;
 			objectDrawOffset = Directions.ToPoint(player.Direction) * 8;
 			pickupTimer = 0;
 			isPickingUp = true;
@@ -139,6 +132,7 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 
 			player.Graphics.PlayAnimation(GameData.ANIM_PLAYER_PULL);
 			AudioSystem.PlaySound(GameData.SOUND_PLAYER_PICKUP);
+			carryEntity.OnPickup();
 		}
 		
 		public override void OnEnd(PlayerState newState) {
@@ -161,15 +155,11 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 				// Handle the 2 frames of picking up.
 				if (pickupTimer < pickupFrame1Duration) {
 					objectZOffset = 0;
-					if (carryObject is CarriedTile)
-						objectDrawOffset.Y -= 2;
 					objectDrawOffset = Directions.ToPoint(player.Direction) * 8;
 					player.Graphics.PlayAnimation(GameData.ANIM_PLAYER_PULL);
 				}
 				else if (pickupTimer < pickupFrame1Duration + pickupFrame2Duration) {
 					objectZOffset = 8;
-					if (carryObject is CarriedTile)
-						objectDrawOffset.Y -= 2;
 					objectDrawOffset = Directions.ToPoint(player.Direction) * 2;
 					player.Graphics.PlayAnimation(GameData.ANIM_PLAYER_GRAB);
 				}
@@ -179,6 +169,7 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 					isPickingUp = false;
 					StateParameters.ProhibitMovementControl	= false;
 					PlayerAnimations.Default = player.Animations.Carry;
+					carryEntity.OnCarry();
 				}
 			}
 			else {
@@ -187,43 +178,39 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 				// Update the carried object.
 				objectDrawOffset		= Point2I.Zero;
 				objectZOffset			= 13;
-				carryObject.RoomControl	= player.RoomControl;
-				carryObject.Position	= player.Position;
-				carryObject.ZPosition	= player.ZPosition + 16;
-				carryObject.UpdateCarrying();
+				carryEntity.RoomControl	= player.RoomControl;
+				carryEntity.Position	= player.Position;
+				carryEntity.ZPosition	= player.ZPosition + 16;
 
-				if (carryObject.IsDestroyed) {
-					End();
-					return;
-				}
 			}
-			carryObject.Graphics.Update();
-			carryObject.Physics.SurfacePosition = player.Physics.SurfacePosition;
+			carryEntity.Physics.SurfacePosition = player.Physics.SurfacePosition;
+
+			carryEntity.UpdateCarrying(isPickingUp);
+			if (carryEntity.IsDestroyed) {
+				End();
+				return;
+			}
 		}
 		
 		public override void DrawOver(RoomGraphics g) {
-			carryObject.Position	= player.Position + objectDrawOffset;
-			carryObject.ZPosition	= player.ZPosition + objectZOffset;
+			carryEntity.Position	= player.Position + objectDrawOffset;
+			carryEntity.ZPosition	= player.ZPosition + objectZOffset;
 			if (!isPickingUp && Directions.IsHorizontal(player.Direction))
-				carryObject.ZPosition += 1;
+				carryEntity.ZPosition += 1;
 
 			// Handle head bobbing when the player is moving horizontally.
 			float playbackTime = player.Graphics.AnimationPlayer.PlaybackTime;
 			if (!isPickingUp && Directions.IsHorizontal(player.Direction)
 				&& playbackTime >= 2 && playbackTime < 8) // TODO: magic number
 			{
-				carryObject.ZPosition -= 1;
+				carryEntity.ZPosition -= 1;
 			}
 
 			// Draw the object.
-			carryObject.Physics.SurfacePosition = player.Physics.SurfacePosition;
-			carryObject.Graphics.Draw(g, DepthLayer.ProjectileCarriedTile);
+			carryEntity.Physics.SurfacePosition = player.Physics.SurfacePosition;
+			carryEntity.Position += carryEntity.CarriedDrawOffset;
+			carryEntity.DrawCarrying(g, isPickingUp);
+			carryEntity.Position -= carryEntity.CarriedDrawOffset;
 		}
-
-
-		//-----------------------------------------------------------------------------
-		// Properties
-		//-----------------------------------------------------------------------------
-
 	}
 }

--- a/ZeldaOracle/Game/Game/Entities/Projectiles/MonsterProjectiles/FireShooterProjectile.cs
+++ b/ZeldaOracle/Game/Game/Entities/Projectiles/MonsterProjectiles/FireShooterProjectile.cs
@@ -92,7 +92,7 @@ namespace ZeldaOracle.Game.Entities.Projectiles.MonsterProjectiles {
 		public override void OnCollideSolidEntity(Entity entity) {
 			//if (entity is MagnetBall) {
 				Effect effect = new Effect(GameData.ANIM_EFFECT_BLOCK_POOF,
-							Entities.DepthLayer.EffectSomariaBlockPoof);
+							Entities.DepthLayer.EffectBlockPoof);
 				RoomControl.SpawnEntity(effect, Position);
 				AudioSystem.PlaySound(GameData.SOUND_APPEAR_VANISH);
 			//}

--- a/ZeldaOracle/Game/Game/Entities/Projectiles/PlayerProjectiles/Bomb.cs
+++ b/ZeldaOracle/Game/Game/Entities/Projectiles/PlayerProjectiles/Bomb.cs
@@ -35,7 +35,10 @@ namespace ZeldaOracle.Game.Entities.Projectiles.PlayerProjectiles {
 			
 			Physics.CollisionBox		= new Rectangle2F(-3, -5, 6, 1);
 			Physics.SoftCollisionBox	= new Rectangle2F(-3, -5, 6, 1);
+			Physics.BraceletCollisionBox	= new Rectangle2I(-4, -9, 8, 8);
 			soundBounce					= GameData.SOUND_BOMB_BOUNCE;
+
+			IsPickupable = true;
 
 			Graphics.DepthLayer			= DepthLayer.ProjectileBomb;
 			Graphics.DrawOffset			= new Point2I(-8, -13);
@@ -102,14 +105,25 @@ namespace ZeldaOracle.Game.Entities.Projectiles.PlayerProjectiles {
 			Graphics.PauseAnimation();
 		}
 
-		public override void UpdateCarrying() {
-			BurnFuse();
-			Graphics.Update();
-		}
-
 		public override void Update() {
 			base.Update();
 			BurnFuse();
+		}
+
+
+		//-----------------------------------------------------------------------------
+		// Carrying Override Methods
+		//-----------------------------------------------------------------------------
+
+		/// <summary>Updates the pickupable entity while being carried.</summary>
+		public override void UpdateCarrying(bool isPickingUp) {
+			Graphics.Update();
+			BurnFuse();
+		}
+
+		/// <summary>Draws the pickupable entity while being carried.</summary>
+		public override void DrawCarrying(RoomGraphics g, bool isPickingUp) {
+			Graphics.Draw(g, DepthLayer.ProjectileCarriedTile);
 		}
 	}
 }

--- a/ZeldaOracle/Game/Game/Entities/Projectiles/PlayerProjectiles/PlayerBoomerang.cs
+++ b/ZeldaOracle/Game/Game/Entities/Projectiles/PlayerProjectiles/PlayerBoomerang.cs
@@ -88,7 +88,7 @@ namespace ZeldaOracle.Game.Entities.Projectiles.PlayerProjectiles {
 
 			// Pickup collectibles.
 			foreach (Collectible collectible in Physics.GetEntitiesMeeting<Collectible>(CollisionBoxType.Soft)) {
-				if (collectible.IsPickupable && collectible.IsCollectibleWithItems) {
+				if (collectible.IsCollectible && collectible.IsCollectibleWithItems) {
 					collectibles.Add(collectible);
 					collectible.Destroy();
 					BeginReturn();

--- a/ZeldaOracle/Game/Game/Entities/Projectiles/PlayerProjectiles/SwitchHookProjectile.cs
+++ b/ZeldaOracle/Game/Game/Entities/Projectiles/PlayerProjectiles/SwitchHookProjectile.cs
@@ -197,7 +197,7 @@ namespace ZeldaOracle.Game.Entities.Projectiles.PlayerProjectiles {
 
 				// Check for collectibles to pick up.
 				foreach (Collectible c in Physics.GetEntitiesMeeting<Collectible>(CollisionBoxType.Soft)) {
-					if (c.IsPickupable && c.IsCollectibleWithItems) {
+					if (c.IsCollectible && c.IsCollectibleWithItems) {
 						collectible = c;
 						c.Destroy();
 						BeginReturn(true);

--- a/ZeldaOracle/Game/Game/Entities/Projectiles/Seeds/SeedProjectile.cs
+++ b/ZeldaOracle/Game/Game/Entities/Projectiles/Seeds/SeedProjectile.cs
@@ -28,7 +28,7 @@ namespace ZeldaOracle.Game.Entities.Projectiles.Seeds {
 		{
 			// Physics.
 			Physics.CollisionBox		= new Rectangle2F(-1, -5, 2, 1);
-			Physics.SoftCollisionBox	= new Rectangle2F(-1, -5, 2, 1);
+			Physics.SoftCollisionBox	= new Rectangle2F(-4, -9, 8, 10);
 			EnablePhysics(
 				PhysicsFlags.DestroyedOutsideRoom |
 				PhysicsFlags.CollideWorld |

--- a/ZeldaOracle/Game/Game/GameSettings.cs
+++ b/ZeldaOracle/Game/Game/GameSettings.cs
@@ -141,6 +141,13 @@ namespace ZeldaOracle.Game {
 		public const float              PLAYER_LEAP_LEDGE_JUMP_SPEED		= 1.75f;
 		public const float				PLAYER_MAGNET_GLOVE_MOVE_SPEED		= 1.5f;
 
+		public static readonly Rectangle2F[] PLAYER_BRACELET_BOXES = {
+			new Rectangle2I(-2, -7, 13, 13),
+			new Rectangle2I(-6, -13, 12, 13),
+			new Rectangle2I(-11, -7, 13, 13),
+			new Rectangle2I(-6, -2, 12, 13),
+		};
+
 		// Monsters
 		public const int				MONSTER_STUN_DURATION					= 400;	// How long a monster gets stunned for (by boomerang/pegasus seeds).
 		public const int				MONSTER_STUN_SHAKE_DURATION				= 60;	// How long the monster shakes at the end of being stunned.

--- a/ZeldaOracle/Game/Game/Items/Weapons/ItemBombs.cs
+++ b/ZeldaOracle/Game/Game/Items/Weapons/ItemBombs.cs
@@ -57,7 +57,9 @@ namespace ZeldaOracle.Game.Items {
 			else {
 				// Pickup a bomb from the ground
 				Bomb bomb = bombTracker.GetEntity();
-				if (bomb != null && Player.Physics.IsSoftMeetingEntity(bomb)) {
+				if (bomb != null && bomb.IsPickupable && Player.Physics.IsBraceletMeetingEntity(
+					bomb, GameSettings.PLAYER_BRACELET_BOXES[Player.Direction]))
+				{
 					Player.CarryState.SetCarryObject(bomb);
 					Player.BeginWeaponState(Player.CarryState);
 					bomb.RemoveFromRoom();

--- a/ZeldaOracle/Game/Game/Items/Weapons/ItemBracelet.cs
+++ b/ZeldaOracle/Game/Game/Items/Weapons/ItemBracelet.cs
@@ -2,10 +2,12 @@
 using ZeldaOracle.Game.Tiles;
 using ZeldaOracle.Common.Graphics.Sprites;
 using ZeldaOracle.Game.Entities.Collisions;
+using ZeldaOracle.Game.Entities;
+using ZeldaOracle.Common.Geometry;
+using ZeldaOracle.Game.Entities.Monsters;
 
 namespace ZeldaOracle.Game.Items.Weapons {
 	public class ItemBracelet : ItemWeapon {
-
 
 		//-----------------------------------------------------------------------------
 		// Constructor
@@ -35,8 +37,29 @@ namespace ZeldaOracle.Game.Items.Weapons {
 			// Check for a tile to grab
 			if (!Player.IsBeingKnockedBack) {
 				Tile grabTile = Player.GrabState.GetGrabTile();
-				if (grabTile != null)
+				if (grabTile != null) {
 					grabTile.OnGrab(Player.Direction, this);
+					return;
+				}
+				foreach (Entity entity in RoomControl.Entities) {
+					if (entity.IsPickupable && Player.Physics.IsBraceletMeetingEntity(
+						entity, GameSettings.PLAYER_BRACELET_BOXES[Player.Direction]))
+					{
+						Player.CarryState.SetCarryObject(entity);
+						Player.BeginWeaponState(Player.CarryState);
+						entity.RemoveFromRoom();
+						return;
+					}
+					else if (entity is Monster && Player.Physics.IsBraceletMeetingEntity(
+						entity, GameSettings.PLAYER_BRACELET_BOXES[Player.Direction]))
+					{
+						((Monster) entity).TriggerInteraction(InteractionType.Bracelet,
+							Player, new WeaponInteractionEventArgs() {
+								Weapon = this
+						});
+						return;
+					}
+				}
 			}
 		}
 	}

--- a/ZeldaOracle/Game/Game/Tiles/Custom/TileDigableReward.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Custom/TileDigableReward.cs
@@ -62,7 +62,7 @@ namespace ZeldaOracle.Game.Tiles.Custom {
 						Properties.Set("looted", true);
 						IsEnabled = false;
 					};
-					collectibleReward.PickupableDelay = GameSettings.COLLECTIBLE_DIG_PICKUPABLE_DELAY;
+					collectibleReward.CollectibleDelay = GameSettings.COLLECTIBLE_DIG_PICKUPABLE_DELAY;
 				}
 				dropEntity.Physics.Velocity = Directions.ToVector(direction) * GameSettings.DROP_ENTITY_DIG_VELOCITY;
 			}

--- a/ZeldaOracle/Game/Game/Tiles/Custom/TileLockedBlock.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Custom/TileLockedBlock.cs
@@ -40,7 +40,7 @@ namespace ZeldaOracle.Game.Tiles {
 
 				// Spawn the key and poof effects.
 				RoomControl.SpawnEntity(new EffectUsedItem(GameData.SPR_REWARD_SMALL_KEY), Center);
-				RoomControl.SpawnEntity(new Effect(GameData.ANIM_EFFECT_BLOCK_POOF, DepthLayer.EffectSomariaBlockPoof), Center);
+				RoomControl.SpawnEntity(new Effect(GameData.ANIM_EFFECT_BLOCK_POOF, DepthLayer.EffectBlockPoof), Center);
 
 				// Destroy the tile forever.
 				Properties.Set("enabled", false);

--- a/ZeldaOracle/Game/Game/Tiles/Internal/AppearingTile.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Internal/AppearingTile.cs
@@ -41,7 +41,7 @@ namespace ZeldaOracle.Game.Tiles.Internal {
 				for (int x = 0; x < size.X; x++) {
 					for (int y = 0; y < size.Y; y++) {
 						Effect effect = new Effect(GameData.ANIM_EFFECT_BLOCK_POOF,
-							Entities.DepthLayer.EffectSomariaBlockPoof);
+							Entities.DepthLayer.EffectBlockPoof);
 						Vector2F pos = (Location + new Point2I(x, y) + Vector2F.Half) * GameSettings.TILE_SIZE;
 						RoomControl.SpawnEntity(effect, pos);
 					}

--- a/ZeldaOracle/Game/Game/Tiles/Tile.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Tile.cs
@@ -69,6 +69,7 @@ namespace ZeldaOracle.Game.Tiles {
 		private TileFlags			flags;
 		private Point2I				size;				// How many tile spaces this tile occupies. NOTE: this isn't supported yet.
 		private ISprite				spriteAsObject;		// The sprite for the tile if it were picked up, pushed, etc.
+		private DepthLayer			breakLayer;
 		private Animation			breakAnimation;		// The animation to play when the tile is broken.
 		private Sound				breakSound;			// The sound to play when the tile is broken.
 		private int					pushDelay;			// Number of ticks of pushing before the player can move this tile.
@@ -347,7 +348,7 @@ namespace ZeldaOracle.Game.Tiles {
 			Entity dropEntity = SpawnDrop();
 			if (dropEntity != null) {
 				if (dropEntity is Collectible)
-					(dropEntity as Collectible).PickupableDelay = GameSettings.COLLECTIBLE_DIG_PICKUPABLE_DELAY;
+					(dropEntity as Collectible).CollectibleDelay = GameSettings.COLLECTIBLE_DIG_PICKUPABLE_DELAY;
 
 				dropEntity.Physics.Velocity = Directions.ToVector(direction) * GameSettings.DROP_ENTITY_DIG_VELOCITY;
 			}
@@ -420,7 +421,7 @@ namespace ZeldaOracle.Game.Tiles {
 		public virtual void Break(bool spawnDrops) {
 			// Spawn the break effect.
 			if (breakAnimation != null && !CancelBreakEffect) {
-				Effect breakEffect = new Effect(breakAnimation, DepthLayer.EffectTileBreak, true);
+				Effect breakEffect = new Effect(breakAnimation, breakLayer, true);
 				RoomControl.SpawnEntity(breakEffect, Center);
 			}
 
@@ -590,6 +591,10 @@ namespace ZeldaOracle.Game.Tiles {
 			graphics.Draw(g);
 		}
 
+		public virtual void Draw(RoomGraphics g, DepthLayer depthLayer) {
+			graphics.Draw(g, depthLayer);
+		}
+
 		public virtual void DrawAbove(RoomGraphics g) {
 			graphics.DrawAbove(g);
 		}
@@ -660,6 +665,7 @@ namespace ZeldaOracle.Game.Tiles {
 			tile.tileData			= data;
 			tile.flags				= data.Flags;
 			tile.spriteAsObject		= data.SpriteAsObject;
+			tile.breakLayer			= data.BreakLayer;
 			tile.breakAnimation		= data.BreakAnimation;
 			tile.breakSound			= data.BreakSound;
 			tile.collisionModel		= data.CollisionModel;
@@ -874,6 +880,11 @@ namespace ZeldaOracle.Game.Tiles {
 
 		public ISprite[] SpriteList {
 			get { return tileData.SpriteList; }
+		}
+
+		public DepthLayer BreakLayer {
+			get { return breakLayer; }
+			set { breakLayer = value; }
 		}
 
 		public Animation BreakAnimation {

--- a/ZeldaOracle/Game/Game/Tiles/TileData.cs
+++ b/ZeldaOracle/Game/Game/Tiles/TileData.cs
@@ -9,6 +9,7 @@ using ZeldaOracle.Common.Scripting;
 using ZeldaOracle.Common.Audio;
 using ZeldaOracle.Game.Control.Scripting;
 using ZeldaOracle.Common.Graphics.Sprites;
+using ZeldaOracle.Game.Entities;
 
 namespace ZeldaOracle.Game.Tiles {
 
@@ -18,6 +19,7 @@ namespace ZeldaOracle.Game.Tiles {
 		private ISprite[]			spriteList;
 		private ISprite             spriteAbove;
 		private ISprite				spriteAsObject;
+		private DepthLayer          breakLayer;
 		private Animation			breakAnimation;	// The animation to play when the tile is broken.
 		private Sound				breakSound;
 		private CollisionModel		model;
@@ -35,6 +37,7 @@ namespace ZeldaOracle.Game.Tiles {
 			spriteAbove			= null;
 			spriteAsObject		= null;
 			breakAnimation		= null;
+			breakLayer    = DepthLayer.EffectTileBreak;
 			model               = null;
 			tileBelow			= null;
 
@@ -203,6 +206,11 @@ namespace ZeldaOracle.Game.Tiles {
 				else
 					spriteAsObject = value;
 			}
+		}
+
+		public DepthLayer BreakLayer {
+			get { return breakLayer; }
+			set { breakLayer = value; }
 		}
 
 		public Animation BreakAnimation {

--- a/ZeldaOracle/Game/Game/Tiles/TileDataInstance.cs
+++ b/ZeldaOracle/Game/Game/Tiles/TileDataInstance.cs
@@ -1,6 +1,7 @@
 ﻿using ZeldaOracle.Common.Geometry;
 using ZeldaOracle.Common.Audio;
 using ZeldaOracle.Common.Graphics.Sprites;
+using ZeldaOracle.Game.Entities;
 
 namespace ZeldaOracle.Game.Tiles {
 	public class TileDataInstance : BaseTileDataInstance {
@@ -133,6 +134,10 @@ namespace ZeldaOracle.Game.Tiles {
 
 		public ISprite SpriteAsObject {
 			get { return TileData.SpriteAsObject; }
+		}
+
+		public DepthLayer BreakLayer {
+			get { return TileData.BreakLayer; }
 		}
 
 		public Animation BreakAnimation {

--- a/ZeldaOracle/Game/Game/Tiles/TileFlags.cs
+++ b/ZeldaOracle/Game/Game/Tiles/TileFlags.cs
@@ -122,5 +122,8 @@ namespace ZeldaOracle.Game.Tiles {
 
 		/// <summary>The tile will be skipped when checking for surfaces.</summary>
 		NotSurface = 0x8000,
+
+		/// <summary>True if the carried tile bounces.</summary>
+		Bounces = 0x10000,
 	}
 }

--- a/ZeldaOracle/Game/Game/Tiles/TileGraphicsComponent.cs
+++ b/ZeldaOracle/Game/Game/Tiles/TileGraphicsComponent.cs
@@ -141,6 +141,17 @@ namespace ZeldaOracle.Game.Tiles {
 			else if (tile.Layer == 2)
 				depthLayer = DepthLayer.TileLayer3;
 
+			Draw(g, depthLayer);
+		}
+
+		public void Draw(RoomGraphics g, DepthLayer depthLayer) {
+			if (!isVisible)
+				return;
+
+			// Determine draw position.
+			Vector2F drawPosition = (useAbsoluteDrawPosition ?
+				absoluteDrawPosition : tile.Position);
+
 			drawPosition += (raisedDrawOffset + drawOffset);
 
 			// Draw the tile's as-object sprite.

--- a/ZeldaOracle/Game/Zelda.csproj
+++ b/ZeldaOracle/Game/Zelda.csproj
@@ -308,6 +308,7 @@
     <Compile Include="Game\Entities\Monsters\MonsterGopongaFlower.cs" />
     <Compile Include="Game\Entities\Monsters\MonsterAntiFairy.cs" />
     <Compile Include="Game\Entities\Monsters\MonsterSpikeRoller.cs" />
+    <Compile Include="Game\Entities\Monsters\MonsterSpinyBeetle.cs" />
     <Compile Include="Game\Entities\Monsters\States\MonsterSpawnState.cs" />
     <Compile Include="Common\Util\StateMachineUtility.cs" />
     <Compile Include="Game\Entities\Monsters\MonsterWaterTektike.cs" />

--- a/ZeldaOracle/GameContent/Tiles/ActionTiles/monsters.conscript
+++ b/ZeldaOracle/GameContent/Tiles/ActionTiles/monsters.conscript
@@ -55,6 +55,12 @@ MONSTER "monster_pokey",				"monster_pokey_head",			MonsterPokey,			green;	END;
 MONSTER "monster_peahat",				"monster_peahat",				MonsterPeahat,			red;	END;
 MONSTER "monster_bari",					"monster_bari",					MonsterBari,			blue;	END;
 MONSTER "monster_biri",					"monster_biri",					MonsterBiri,			blue;	END;
+MONSTER "monster_spiny_beetle_bush",	"monster_spiny_beetle",			MonsterSpinyBeetle,		red;
+	PROPERTIES	(string, cover_tile, "bush");
+END;
+MONSTER "monster_spiny_beetle_rock",	"monster_spiny_beetle",			MonsterSpinyBeetle,		red;
+	PROPERTIES	(string, cover_tile, "bracelet_rock");
+END;
 
 
 #==============================================================================

--- a/ZeldaOracle/GameContent/Tiles/Tiles/Objects/general_objects.conscript
+++ b/ZeldaOracle/GameContent/Tiles/Tiles/Objects/general_objects.conscript
@@ -86,8 +86,11 @@ END;
 
 TILE "mushroom";
 	SOLID		block;
-	FLAGS		Pickupable;
+	FLAGS		Pickupable, Bounces;
 	SAMESPRITE; SAMESPRITEOBJ;
+	BREAKLAYER	EffectBlockPoof;
+	BREAKANIM	"effect_block_poof";
+	BREAKSOUND	"appear_vanish";
 END;
 
 # Dirt Pile ---------------------------------------------------


### PR DESCRIPTION
* Fixed BasicMonster charging's directino when numMoveAngles is not 4.
* Renamed BasicMonster's EndCharging to StopChargin.
* BasicMonster.StopCharging now properly starts the move state.
* Charging monsters now stop when about to collide with hazard tiles.
* Added bracelet collision box to physics.
* Entity now contains settings for if they can be picked up
(implemented), or grabbed (unimplemented).
* Player pickup range is no longer the soft collision box but instead a
directional collision box.
* Updated bomb's bracelet collision box.
* Added MonsterSpinyBeetle. Still lots of things to fix and implement
but for the most part they are pretty accurate.
* Renamed InteractionType.Pickup to InteractionType.Bracelet.
* Renamed Depthlayer's EffectSomariaBlockPoof to EffectBlockPoof.
* Fixed carried tiles not mapping correctly.
* Added RangeI/F.Set(float uniform)
* Added EntityTracker.ClearEntities()
* Player now drops tile instead of throwing if hurt during the pickup
phase.
* Updated SeedProjectile's soft collision box.
* Added Tile.BreakLayer for the depth layer to show break effects on.
* Added TileFlags.Bounces for thrown tiles that bounce and land before
breaking.
* Implemented bouncing/poofing pickupable mushroom.