### PR TITLE
Fix Console Output Crash

### DIFF
--- a/ZeldaOracle/Game/Common/Translation/FormatCodes.cs
+++ b/ZeldaOracle/Game/Common/Translation/FormatCodes.cs
@@ -50,7 +50,7 @@ namespace ZeldaOracle.Common.Translation {
 		//-----------------------------------------------------------------------------
 
 		/// <summary>Initializes the format codes.</summary>
-		public static void Initialize() {
+		static FormatCodes() {
 
 			FormatCodes.colorCodes			= new Dictionary<string, ColorOrPalette>();
 			FormatCodes.stringCodes			= new Dictionary<string, string>();

--- a/ZeldaOracle/Game/Common/Util/NativeMethods.cs
+++ b/ZeldaOracle/Game/Common/Util/NativeMethods.cs
@@ -12,6 +12,8 @@ namespace ZeldaOracle.Common.Util {
 		/// console screen buffer, CONOUT$.</summary>
 		public const uint StdOutputHandle = 0xFFFFFFF5;
 
+		public static readonly IntPtr DefaultStdOut = new IntPtr(7);
+
 		/// <summary>Allocates a new console for the calling process.</summary>
 		[DllImport("kernel32.dll")]
 		public static extern bool AllocConsole();

--- a/ZeldaOracle/Game/Game/Main/GameManager.cs
+++ b/ZeldaOracle/Game/Game/Main/GameManager.cs
@@ -58,6 +58,8 @@ namespace ZeldaOracle.Game.Main {
 		private bool			isGamePaused;
 		/// <summary>True if a console window as been allocated for this game.</summary>
 		private bool			isConsoleOpen;
+		/// <summary>The default TextWriter for console output.</summary>
+		private TextWriter      defaultConsoleOut;
 		/// <summary>The user settings for the game.</summary>
 		private UserSettings	userSettings;
 
@@ -83,6 +85,7 @@ namespace ZeldaOracle.Game.Main {
 			this.launchParameters	= launchParameters;
 			this.isGamePaused       = false;
 			this.isConsoleOpen      = false;
+			this.defaultConsoleOut	= Console.Out;
 			this.userSettings       = null;
 
 			this.gameBase.Window.Title = GameName;
@@ -93,8 +96,7 @@ namespace ZeldaOracle.Game.Main {
 		/// <summary>Initializes the game manager.</summary>
 		public void Initialize() {
 			elapsedTicks = 0;
-
-			FormatCodes.Initialize();
+			
 			ScreenResized();
 
 			userSettings	= new UserSettings();
@@ -385,16 +387,14 @@ namespace ZeldaOracle.Game.Main {
 				if (value != isConsoleOpen) {
 					isConsoleOpen = value;
 					if (isConsoleOpen) {
+						// Allocate a new console window
 						NativeMethods.AllocConsole();
-						// stdout's handle seems to always be equal to 7
-						IntPtr defaultStdout = new IntPtr(7);
-						IntPtr currentStdout = NativeMethods.GetStdHandle(NativeMethods.StdOutputHandle);
 
-						if (currentStdout != defaultStdout)
-							// reset stdout
-							NativeMethods.SetStdHandle(NativeMethods.StdOutputHandle, defaultStdout);
+						// Reset StdOut
+						NativeMethods.SetStdHandle(NativeMethods.StdOutputHandle,
+								NativeMethods.DefaultStdOut);
 
-						// reopen stdout
+						// Reopen StdOut
 						TextWriter writer = new StreamWriter(Console.OpenStandardOutput()) {
 							AutoFlush = true
 						};
@@ -404,7 +404,9 @@ namespace ZeldaOracle.Game.Main {
 						gameBase.Form.Activate();
 					}
 					else {
+						// Free the console window
 						NativeMethods.FreeConsole();
+						Console.SetOut(defaultConsoleOut);
 					}
 				}
 			}

--- a/ZeldaOracle/GameEditor/Control/EditorControl.cs
+++ b/ZeldaOracle/GameEditor/Control/EditorControl.cs
@@ -197,7 +197,6 @@ namespace ZeldaEditor.Control {
 
 		public void Initialize() {
 			GameData.Initialize();
-			FormatCodes.Initialize();
 			EditorResources.Initialize(this);
 			paletteShader = new PaletteShader(GameData.PALETTE_LERP_SHADER);
 


### PR DESCRIPTION
* Fixed writing to console causing a crash after closing the game
console.
* Output console now writes to VS Debug Console again after closing the
game console.
* FormatCodes now uses a static initializer.