### PR TITLE
Implement SideScroll Lava & Drowning

### DIFF
--- a/ZeldaOracle/Game/Game/Control/RoomPhysics.cs
+++ b/ZeldaOracle/Game/Game/Control/RoomPhysics.cs
@@ -1086,8 +1086,11 @@ namespace ZeldaOracle.Game.Control {
 				{
 					entity.OnFallInSideScrollWater();
 				}
-				else if (entity.Physics.IsInLava)
-					entity.OnFallInLava();
+				else if (entity.Physics.IsInLava &&
+					(previousTopTile == null || !previousTopTile.IsLava))
+				{
+					entity.OnFallInSideScrollLava();
+				}
 			}
 			else {
 				if (entity.Physics.IsInHole)

--- a/ZeldaOracle/Game/Game/Entities/Entity.cs
+++ b/ZeldaOracle/Game/Game/Entities/Entity.cs
@@ -142,7 +142,19 @@ namespace ZeldaOracle.Game.Entities {
 				DepthLayer.EffectSplash, true), position);
 			AudioSystem.PlaySound(GameData.SOUND_PLAYER_WADE);
 		}
-		
+
+		/// <summary>Called when the entity falls in lava in side-scroll mode
+		/// .</summary>
+		public virtual void OnFallInSideScrollLava() {
+			if (physics.IsDestroyedInHoles) {
+				physics.VelocityX = 0.0f;
+				RoomControl.SpawnEntity(new Effect(
+					GameData.ANIM_EFFECT_LAVA_SPLASH,
+					DepthLayer.EffectSplash, true), position);
+				AudioSystem.PlaySound(GameData.SOUND_PLAYER_WADE);
+			}
+		}
+
 		/// <summary>Called when the entity falls in water.</summary>
 		public virtual void OnFallInWater() {
 			if (physics.IsDestroyedInHoles) {

--- a/ZeldaOracle/Game/Game/Entities/PhysicsComponent.cs
+++ b/ZeldaOracle/Game/Game/Entities/PhysicsComponent.cs
@@ -812,8 +812,8 @@ namespace ZeldaOracle.Game.Entities {
 
 		public bool IsInWater {
 			get {
-				return ((IsOnGround && !DisableSurfaceContact) ||
-					entity.RoomControl.IsSideScrolling) &&
+				return ((IsOnGround || entity.RoomControl.IsSideScrolling) &&
+					!DisableSurfaceContact) &&
 					topTile != null && topTile.IsWater;
 			}
 		}
@@ -855,8 +855,9 @@ namespace ZeldaOracle.Game.Entities {
 
 		public bool IsInLava {
 			get {
-				return IsOnGround && !DisableSurfaceContact && topTile != null &&
-					topTile.IsLava;
+				return ((IsOnGround || entity.RoomControl.IsSideScrolling)
+					&& !DisableSurfaceContact) &&
+					topTile != null && topTile.IsLava;
 			}
 		}
 

--- a/ZeldaOracle/Game/Game/Entities/Players/EnvironmentStates/PlayerSideScrollSwimEnvironmentState.cs
+++ b/ZeldaOracle/Game/Game/Entities/Players/EnvironmentStates/PlayerSideScrollSwimEnvironmentState.cs
@@ -48,6 +48,29 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 			AudioSystem.PlaySound(GameData.SOUND_PLAYER_WADE);
 		}
 
+		/// <summary>Returns true if the player has the capability to swim in the
+		/// liquid he is currently in.</summary>
+		private bool CanSwimInCurrentLiquid() {
+			if (player.Physics.IsInLava && !player.RoomControl.IsSideScrolling)
+				return player.SwimmingSkills.HasFlag(PlayerSwimmingSkills.CanSwimInLava);
+			else if (player.Physics.IsInOcean)
+				return player.SwimmingSkills.HasFlag(PlayerSwimmingSkills.CanSwimInOcean);
+			else if (player.Physics.IsInWater)
+				return player.SwimmingSkills.HasFlag(PlayerSwimmingSkills.CanSwimInWater);
+			else
+				return false;
+		}
+
+		/// <summary>Make the player die by drowning.</summary>
+		private void Drown() {
+			player.Graphics.PlayAnimation(GameData.ANIM_PLAYER_DROWN);
+
+			if (player.Physics.IsInLava)
+				player.Graphics.IsHurting = true;
+
+			player.RespawnDeath();
+		}
+
 
 		//-----------------------------------------------------------------------------
 		// Overridden methods
@@ -56,6 +79,12 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 		public override void OnBegin(PlayerState previousState) {
 			player.InterruptWeapons();
 			//CreateSplashEffect(); // Now called in Entity.OnFallInSideScrollWater()
+			if (!CanSwimInCurrentLiquid()) {
+				Drown();
+				// TODO: Cancel the hurt animation if the player was knocked in.
+				//player.InvincibleTimer = 0;
+				//player.Graphics.IsHurting = false;
+			}
 		}
 		
 		public override void OnEnd(PlayerState newState) {

--- a/ZeldaOracle/Game/Game/Entities/Players/EnvironmentStates/PlayerSwimEnvironmentState.cs
+++ b/ZeldaOracle/Game/Game/Entities/Players/EnvironmentStates/PlayerSwimEnvironmentState.cs
@@ -97,7 +97,7 @@ namespace ZeldaOracle.Game.Entities.Players.States {
 		/// <summary>Returns true if the player has the capability to swim in the
 		/// liquid he is currently in.</summary>
 		private bool CanSwimInCurrentLiquid() {
-			if (player.Physics.IsInLava)
+			if (player.Physics.IsInLava && !player.RoomControl.IsSideScrolling)
 				return player.SwimmingSkills.HasFlag(PlayerSwimmingSkills.CanSwimInLava);
 			else if (player.Physics.IsInOcean)
 				return player.SwimmingSkills.HasFlag(PlayerSwimmingSkills.CanSwimInOcean);


### PR DESCRIPTION
* PhysicsComponent.IsInWater/Lava modified to support sidescrolling and
fix drowning.
* SideScrollSwim state now checks for swim capabilities and drowns if it
fails.
* Added Entity.OnFallInSideScrollLava
* Now lava will always force a drown in sidescrolling even when the
player has lava swimming capabilities. (Because Lava is impossible to
see in due to DrawAbove)