### PR TITLE
Fix PointPropertyGridEditor errors

### DIFF
--- a/ZeldaOracle/Game/Game/Worlds/Level.cs
+++ b/ZeldaOracle/Game/Game/Worlds/Level.cs
@@ -415,7 +415,7 @@ namespace ZeldaOracle.Game.Worlds {
 					if (oldRooms != null && x < dimensions.X && y < dimensions.Y)
 						rooms[x, y] = oldRooms[x, y];
 					else
-						rooms[x, y] = new Room(this, x, y, Zone ?? GameData.ZONE_DEFAULT);
+						rooms[x, y] = new Room(this, x, y);
 				}
 			}
 
@@ -434,7 +434,7 @@ namespace ZeldaOracle.Game.Worlds {
 					else if (restoredRooms.ContainsKey(new Point2I(x, y)))
 						rooms[x, y] = restoredRooms[new Point2I(x, y)];
 					else
-						rooms[x, y] = new Room(this, x, y, Zone ?? GameData.ZONE_DEFAULT);
+						rooms[x, y] = new Room(this, x, y);
 				}
 			}
 
@@ -454,7 +454,7 @@ namespace ZeldaOracle.Game.Worlds {
 						rooms[x, y].Location = new Point2I(x, y);
 					}
 					else
-						rooms[x, y] = new Room(this, x, y, Zone ?? Resources.GetResource<Zone>(""));
+						rooms[x, y] = new Room(this, x, y);
 				}
 			}
 		}
@@ -477,7 +477,7 @@ namespace ZeldaOracle.Game.Worlds {
 						rooms[x, y].Location = location;
 					}
 					else
-						rooms[x, y] = new Room(this, location, Zone ?? Resources.GetResource<Zone>(""));
+						rooms[x, y] = new Room(this, location);
 				}
 			}
 		}

--- a/ZeldaOracle/GameEditor/Themes/Generic.xaml
+++ b/ZeldaOracle/GameEditor/Themes/Generic.xaml
@@ -2026,7 +2026,7 @@
         <Setter Property="IsTabStop"  Value="False" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="TextAlignment" Value="Right" />
-        <Setter Property="WatermarkTemplate" Value="{StaticResource DefaultWatermarkTemplate}" />
+        <!--<Setter Property="WatermarkTemplate" Value="{StaticResource DefaultWatermarkTemplate}" />-->
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type local:PointUpDown}">
@@ -2071,9 +2071,9 @@
                                           TextAlignment="{Binding TextAlignment, RelativeSource={RelativeSource TemplatedParent}}"
                                           TextWrapping="NoWrap" 
                                           TabIndex="{TemplateBinding TabIndex}"
-                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          Watermark="{Binding Watermark, RelativeSource={RelativeSource TemplatedParent}}"
-                                          WatermarkTemplate="{Binding WatermarkTemplate, RelativeSource={RelativeSource TemplatedParent}}" />
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                          <!--Watermark="{Binding Watermark, RelativeSource={RelativeSource TemplatedParent}}"
+                                          WatermarkTemplate="{Binding WatermarkTemplate, RelativeSource={RelativeSource TemplatedParent}}" />-->
                         </xctk:ButtonSpinner>
                     </xctk:ButtonSpinner>
                     <ControlTemplate.Triggers>


### PR DESCRIPTION
* PointPropertyGridEditor no longer throws silent errors.
* Level's creation of rooms no longer supplies a default zone so that
room zones use the level's zone by default.