### PR TITLE
Property Undo Actions no longer lose link to created objects

### DIFF
--- a/ZeldaOracle/GameEditor/Tools/ToolPointer.cs
+++ b/ZeldaOracle/GameEditor/Tools/ToolPointer.cs
@@ -59,6 +59,8 @@ namespace ZeldaEditor.Tools {
 				action.AddOverwrittenActionTile(selectedActionTile);
 				EditorControl.PushAction(action, ActionExecution.Execute);
 			}
+			LevelDisplay.ClearSelectionBox();
+			EditorControl.EditingTileData = null;
 			selectedActionTile	= null;
 			selectedTile		= null;
 			selectedRoom		= null;
@@ -70,6 +72,8 @@ namespace ZeldaEditor.Tools {
 		}
 
 		public override void Deselect() {
+			LevelDisplay.ClearSelectionBox();
+			EditorControl.EditingTileData = null;
 			selectedActionTile	= null;
 			selectedTile		= null;
 			selectedRoom        = null;

--- a/ZeldaOracle/GameEditor/Undo/ActionResizeLevel.cs
+++ b/ZeldaOracle/GameEditor/Undo/ActionResizeLevel.cs
@@ -15,6 +15,7 @@ namespace ZeldaEditor.Undo {
 		private Point2I oldSize;
 		private Point2I newSize;
 		private Dictionary<Point2I, Room> cutoffRooms;
+		private Dictionary<Point2I, Room> cutinRooms;
 
 		public ActionResizeLevel(Level level, Point2I newSize) {
 			ActionName = "Resize Level";
@@ -22,43 +23,64 @@ namespace ZeldaEditor.Undo {
 			this.level = level;
 			this.oldSize = level.Dimensions;
 			this.newSize = newSize;
-			if (!(oldSize <= newSize)) {
+			if (oldSize != newSize) {
 				this.cutoffRooms = new Dictionary<Point2I, Room>();
-				if (oldSize.X > newSize.X) {
-					for (int x = newSize.X; x < oldSize.X; x++) {
-						for (int y = 0; y < oldSize.Y; y++) {
-							AddRoom(new Point2I(x, y), level.GetRoomAt(x, y));
-						}
+				this.cutinRooms = new Dictionary<Point2I, Room>();
+				Point2I max = GMath.Max(oldSize, newSize);
+				for (int x = newSize.X; x < oldSize.X; x++) {
+					for (int y = 0; y < max.Y; y++) {
+						AddCutoffRoom(new Point2I(x, y), level.GetRoomAt(x, y));
 					}
 				}
-				if (oldSize.Y > newSize.Y) {
-					for (int x = 0; x < oldSize.X; x++) {
-						for (int y = newSize.Y; y < oldSize.Y; y++) {
-							AddRoom(new Point2I(x, y), level.GetRoomAt(x, y));
-						}
+				for (int y = newSize.Y; y < oldSize.Y; y++) {
+					for (int x = 0; x < max.X; x++) {
+						AddCutoffRoom(new Point2I(x, y), level.GetRoomAt(x, y));
 					}
 				}
 			}
 		}
 
-		private void AddRoom(Point2I point, Room room) {
+		private void AddCutoffRoom(Point2I point, Room room) {
 			if (!cutoffRooms.ContainsKey(point))
 				cutoffRooms.Add(point, room);
 		}
 
+		private void AddCutinRoom(Point2I point, Room room) {
+			if (!cutinRooms.ContainsKey(point))
+				cutinRooms.Add(point, room);
+		}
+
+		public override void Execute(EditorControl editorControl) {
+			level.Resize(newSize);
+			// Store the newly created rooms to keep links to property objects
+			Point2I max = GMath.Max(oldSize, newSize);
+			for (int x = oldSize.X; x < newSize.X; x++) {
+				for (int y = 0; y < max.Y; y++) {
+					AddCutinRoom(new Point2I(x, y), level.GetRoomAt(x, y));
+				}
+			}
+			for (int y = oldSize.Y; y < newSize.Y; y++) {
+				for (int x = 0; x < max.X; x++) {
+					AddCutinRoom(new Point2I(x, y), level.GetRoomAt(x, y));
+				}
+			}
+			editorControl.OpenLevel(level);
+			editorControl.LevelDisplay.UpdateLevel();
+			editorControl.NeedsNewEventCache = true;
+		}
+
 		public override void Undo(EditorControl editorControl) {
 			editorControl.OpenLevel(level);
-			if (!(oldSize <= newSize))
-				level.Resize(oldSize, cutoffRooms);
-			else
-				level.Resize(oldSize);
+			level.Resize(oldSize, cutoffRooms);
 			editorControl.LevelDisplay.UpdateLevel();
+			editorControl.NeedsNewEventCache = true;
 		}
 
 		public override void Redo(EditorControl editorControl) {
 			editorControl.OpenLevel(level);
-			level.Resize(newSize);
+			level.Resize(newSize, cutinRooms);
 			editorControl.LevelDisplay.UpdateLevel();
+			editorControl.NeedsNewEventCache = true;
 		}
 
 		public override bool IgnoreAction { get { return oldSize == newSize; } }


### PR DESCRIPTION
* Fixed all instances of undoing a create/duplicate action not storing
the created tile thus, the link to the IProperty and IEvent Objects were
becoming useless for undo actions.