### PR TITLE
Sprite Infinite Containment Loop Prevention

### DIFF
--- a/ZeldaOracle/Game/Common/Graphics/Sprites/BasicSprite.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Sprites/BasicSprite.cs
@@ -89,6 +89,16 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 			return new SpritePart(image, sourceRect, drawOffset/*, flipEffects, rotation*/);
 		}
 
+		/// <summary>Gets all sprites contained by this sprite including this one.</summary>
+		public IEnumerable<ISprite> GetAllSprites() {
+			yield return this;
+		}
+
+		/// <summary>Returns true if this sprite contains the specified sprite.</summary>
+		public bool ContainsSubSprite(ISprite sprite) {
+			return false;
+		}
+
 		/// <summary>Clones the sprite.</summary>
 		public ISprite Clone() {
 			return new BasicSprite(this);

--- a/ZeldaOracle/Game/Common/Graphics/Sprites/CompositeSprite.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Sprites/CompositeSprite.cs
@@ -55,6 +55,21 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 			return firstPart;
 		}
 
+		/// <summary>Gets all sprites contained by this sprite including this one.</summary>
+		public IEnumerable<ISprite> GetAllSprites() {
+			yield return this;
+			foreach (ISprite sprite in sprites) {
+				foreach (ISprite subsprite in sprite.GetAllSprites()) {
+					yield return subsprite;
+				}
+			}
+		}
+
+		/// <summary>Returns true if this sprite contains the specified sprite.</summary>
+		public bool ContainsSubSprite(ISprite sprite) {
+			return GetAllSprites().Contains(sprite);
+		}
+
 		/// <summary>Clones the sprite.</summary>
 		public ISprite Clone() {
 			return new CompositeSprite(this);
@@ -125,43 +140,51 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 
 		/// <summary>Adds the offset sprite to the list after making a copy of it.</summary>
 		public void AddOffsetSprite(OffsetSprite sprite) {
+			if (sprite != null && sprite.ContainsSubSprite(this))
+				throw new SpriteContainmentException(this, sprite.Sprite);
 			sprites.Add(new OffsetSprite(sprite));
 		}
 
 		/// <summary>Adds a new sprite to the list.</summary>
 		public void AddSprite(ISprite sprite, Rectangle2I? clipping = null, Flip flip = Flip.None, Rotation rotation = Rotation.None) {
-			sprites.Add(new OffsetSprite(sprite, clipping, flip, rotation));
+			AddOffsetSprite(new OffsetSprite(sprite, clipping, flip, rotation));
 		}
 
 		/// <summary>Adds a new sprite to the list.</summary>
 		public void AddSprite(ISprite sprite, Point2I drawOffset, Rectangle2I? clipping = null, Flip flip = Flip.None, Rotation rotation = Rotation.None) {
-			sprites.Add(new OffsetSprite(sprite, drawOffset, clipping, flip, rotation));
+			AddOffsetSprite(new OffsetSprite(sprite, drawOffset, clipping, flip, rotation));
 		}
 
 		/// <summary>Inserts the offset sprite into the list after making a copy of it.</summary>
 		public void InsertOffsetSprite(int index, OffsetSprite sprite) {
+			if (sprite != null && sprite.ContainsSubSprite(this))
+				throw new SpriteContainmentException(this, sprite.Sprite);
 			sprites.Insert(index, new OffsetSprite(sprite));
 		}
 
 		/// <summary>Inserts a new sprite into the list.</summary>
 		public void InsertSprite(int index, ISprite sprite, Rectangle2I? clipping = null, Flip flip = Flip.None, Rotation rotation = Rotation.None) {
-			sprites.Insert(index, new OffsetSprite(sprite, clipping, flip, rotation));
+			InsertOffsetSprite(index, new OffsetSprite(sprite, clipping, flip, rotation));
 		}
 
 		/// <summary>Inserts a new sprite into the list.</summary>
 		public void InsertSprite(int index, ISprite sprite, Point2I drawOffset, Rectangle2I? clipping = null, Flip flip = Flip.None, Rotation rotation = Rotation.None) {
-			sprites.Insert(index, new OffsetSprite(sprite, drawOffset, clipping, flip, rotation));
+			InsertOffsetSprite(index, new OffsetSprite(sprite, drawOffset, clipping, flip, rotation));
 		}
 
 		/// <summary>Replaces the sprite at the specified index in the list and keeps
 		/// its offset settings.</summary>
 		public void ReplaceSprite(int index, ISprite sprite) {
+			if (sprite != null && sprite.ContainsSubSprite(this))
+				throw new SpriteContainmentException(this, sprite);
 			sprites[index].Sprite = sprite;
 		}
 
 		/// <summary>Replaces the sprite at the specified index in the list and changes
 		/// its offset settings.</summary>
 		public void ReplaceSprite(int index, ISprite sprite, Point2I drawOffset, Rectangle2I? clipping = null, Flip flip = Flip.None, Rotation rotation = Rotation.None) {
+			if (sprite != null && sprite.ContainsSubSprite(this))
+				throw new SpriteContainmentException(this, sprite);
 			sprites[index].Sprite = sprite;
 			sprites[index].DrawOffset = drawOffset;
 			sprites[index].Clipping = clipping;

--- a/ZeldaOracle/Game/Common/Graphics/Sprites/DefinitionSprite.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Sprites/DefinitionSprite.cs
@@ -49,7 +49,9 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 			this.group          = group;
 			this.definitions    = new Dictionary<string, ISprite>();
 			this.defaultSprite  = firstSprite;
-			this.definitions.Add(firstDefinition, firstSprite);
+
+			// Call Add for containment checks
+			this.Add(firstDefinition, firstSprite);
 		}
 
 		/// <summary>Constructs a copy of the definition sprite.</summary>
@@ -84,6 +86,21 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 			if (defaultSprite != null)
 				return defaultSprite.GetParts(settings);
 			return null;
+		}
+
+		/// <summary>Gets all sprites contained by this sprite including this one.</summary>
+		public IEnumerable<ISprite> GetAllSprites() {
+			yield return this;
+			foreach (var pair in definitions) {
+				foreach (ISprite subsprite in pair.Value.GetAllSprites()) {
+					yield return subsprite;
+				}
+			}
+		}
+
+		/// <summary>Returns true if this sprite contains the specified sprite.</summary>
+		public bool ContainsSubSprite(ISprite sprite) {
+			return GetAllSprites().Contains(sprite);
 		}
 
 		/// <summary>Clones the sprite.</summary>
@@ -147,6 +164,8 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 
 		/// <summary>Adds the sprite definition to the sprite.</summary>
 		public void Add(string definintion, ISprite sprite) {
+			if (sprite != null && sprite.ContainsSubSprite(this))
+				throw new SpriteContainmentException(this, sprite);
 			if (definintion == null)
 				throw new ArgumentNullException("Definition cannot be null!");
 			if (sprite == null)
@@ -158,6 +177,8 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 
 		/// <summary>Sets the sprite definition for the sprite.</summary>
 		public void Set(string definintion, ISprite sprite) {
+			if (sprite != null && sprite.ContainsSubSprite(this))
+				throw new SpriteContainmentException(this, sprite);
 			if (definintion == null)
 				throw new ArgumentNullException("Definition cannot be null!");
 			if (sprite == null)

--- a/ZeldaOracle/Game/Common/Graphics/Sprites/EmptySprite.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Sprites/EmptySprite.cs
@@ -18,6 +18,16 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 			return null;
 		}
 
+		/// <summary>Gets all sprites contained by this sprite including this one.</summary>
+		public IEnumerable<ISprite> GetAllSprites() {
+			yield return this;
+		}
+
+		/// <summary>Returns true if this sprite contains the specified sprite.</summary>
+		public bool ContainsSubSprite(ISprite sprite) {
+			return false;
+		}
+
 		/// <summary>Clones the sprite.</summary>
 		public ISprite Clone() {
 			return new EmptySprite();

--- a/ZeldaOracle/Game/Common/Graphics/Sprites/GroupDefinitions.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Sprites/GroupDefinitions.cs
@@ -106,7 +106,10 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 	public class ColorDefinitions : GroupDefinitions {
 		
 		/// <summary>An empty collection of group definitions.</summary>
-		public static readonly ColorDefinitions Empty = new ColorDefinitions();
+		public static ColorDefinitions Empty {
+			get { return new ColorDefinitions(); }
+		}
+
 
 		/// <summary>Constructs a new collection of color definitions.</summary>
 		public ColorDefinitions() { }
@@ -120,6 +123,7 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 			definitions.Set("all", definition);
 			return definitions;
 		}
+
 
 		/// <summary>Sets all groups to the same definition.</summary>
 		public void SetAll(string definition) {
@@ -135,14 +139,16 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 	/// <summary>A collection of style definitions for what styles to use.</summary>
 	public class StyleDefinitions : GroupDefinitions {
 
+		/// <summary>An empty collection of group definitions.</summary>
+		public static StyleDefinitions Empty {
+			get { return new StyleDefinitions(); }
+		}
+
+
 		/// <summary>Constructs a new collection of style definitions.</summary>
 		public StyleDefinitions() { }
 
 		/// <summary>Constructs a copy of the collection of style definitions.</summary>
 		public StyleDefinitions(StyleDefinitions copy) : base(copy) { }
-
-		/// <summary>An empty collection of group definitions.</summary>
-		public static readonly StyleDefinitions Empty = new StyleDefinitions();
-
 	}
 }

--- a/ZeldaOracle/Game/Common/Graphics/Sprites/ISprite.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Sprites/ISprite.cs
@@ -11,6 +11,12 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 		/// <summary>Gets the linked list of drawable parts of the sprite.</summary>
 		SpritePart GetParts(SpriteSettings settings);
 
+		/// <summary>Gets all sprites contained by this sprite including this one.</summary>
+		IEnumerable<ISprite> GetAllSprites();
+
+		/// <summary>Returns true if this sprite contains the specified sprite.</summary>
+		bool ContainsSubSprite(ISprite sprite);
+
 		/// <summary>Clones the sprite.</summary>
 		ISprite Clone();
 
@@ -19,5 +25,26 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 
 		/// <summary>Gets the draw boundaries of the sprite.</summary>
 		Rectangle2I Bounds { get; }
+	}
+
+	/// <summary>An exception thrown when trying to add a subsprite to a sprite
+	/// that is contained by the subsprite.</summary>
+	public class SpriteContainmentException : Exception {
+		/// <summary>Constructs the exception with the specified offending sprites.</summary>
+		public SpriteContainmentException(ISprite sprite, ISprite subsprite)
+			: this(sprite.GetType().Name, subsprite.GetType().Name) { }
+
+		/// <summary>Constructs the exception with the specified offending sprites.</summary>
+		public SpriteContainmentException(ISprite sprite, string subSpriteName)
+			: this(sprite.GetType().Name, subSpriteName) { }
+
+		/// <summary>Constructs the exception with the specified offending sprites.</summary>
+		public SpriteContainmentException(string spriteName, ISprite subsprite)
+			: this(spriteName, subsprite.GetType().Name) { }
+
+		/// <summary>Constructs the exception with the specified offending sprites.</summary>
+		public SpriteContainmentException(string spriteName, string subSpriteName)
+			: base(subSpriteName + " cannot be added to " +
+				  spriteName + " because it would contain itself!") { }
 	}
 }

--- a/ZeldaOracle/Game/Common/Graphics/Sprites/OffsetSprite.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Sprites/OffsetSprite.cs
@@ -38,7 +38,8 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 		public OffsetSprite(ISprite sprite, Rectangle2I? clipping = null, Flip flip = Flip.None,
 			Rotation rotation = Rotation.None)
 		{
-			this.sprite			= sprite;
+			// Call sprite property for containment checking
+			this.Sprite			= sprite;
 			this.drawOffset		= Point2I.Zero;
 			this.clipping		= clipping;
 			this.flipEffects	= flip;
@@ -49,7 +50,8 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 		public OffsetSprite(ISprite sprite, Point2I drawOffset, Rectangle2I? clipping = null,
 			Flip flip = Flip.None, Rotation rotation = Rotation.None)
 		{
-			this.sprite			= sprite;
+			// Call sprite property for containment checking
+			this.Sprite			= sprite;
 			this.drawOffset		= drawOffset;
 			this.clipping		= clipping;
 			this.flipEffects	= flip;
@@ -81,6 +83,21 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 				parts = parts.NextPart;
 			}
 			return firstPart;
+		}
+
+		/// <summary>Gets all sprites contained by this sprite including this one.</summary>
+		public IEnumerable<ISprite> GetAllSprites() {
+			yield return this;
+			if (sprite != null) {
+				foreach (ISprite subsprite in sprite.GetAllSprites()) {
+					yield return subsprite;
+				}
+			}
+		}
+
+		/// <summary>Returns true if this sprite contains the specified sprite.</summary>
+		public bool ContainsSubSprite(ISprite sprite) {
+			return GetAllSprites().Contains(sprite);
 		}
 
 		/// <summary>Clones the sprite.</summary>
@@ -130,7 +147,11 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 		/// <summary>Gets or sets the sprite of the offset sprite.</summary>
 		public ISprite Sprite {
 			get { return sprite; }
-			set { sprite = value; }
+			set {
+				if (value != null && value.ContainsSubSprite(this))
+					throw new SpriteContainmentException(this, value);
+				sprite = value;
+			}
 		}
 
 		/// <summary>Gets or sets the extra draw offset of the offset sprite.</summary>

--- a/ZeldaOracle/Game/Common/Graphics/Sprites/UnmappedSprite.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Sprites/UnmappedSprite.cs
@@ -42,6 +42,16 @@ namespace ZeldaOracle.Common.Graphics.Sprites {
 			return new SpritePart(Image, Image.Bounds, DrawOffset/*, flipEffects, rotation*/);
 		}
 
+		/// <summary>Gets all sprites contained by this sprite including this one.</summary>
+		public IEnumerable<ISprite> GetAllSprites() {
+			yield return this;
+		}
+
+		/// <summary>Returns true if this sprite contains the specified sprite.</summary>
+		public bool ContainsSubSprite(ISprite sprite) {
+			return false;
+		}
+
 		/// <summary>Clones the sprite.</summary>
 		public ISprite Clone() {
 			return new UnmappedSprite(this);


### PR DESCRIPTION
* Now, whenever you add a subsprite to a sprite, it will check if the
subsprite contains the parent sprite and throw an error if it does.