### PR TITLE
Fix Refactor Window & Read Only Properties

### DIFF
--- a/EditorLibraries/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinition.cs
+++ b/EditorLibraries/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinition.cs
@@ -73,7 +73,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid {
 		#region Override Methods
 
 		internal override ObjectContainerHelperBase CreateContainerHelper(IPropertyContainer parent) {
-			return new ObjectContainerHelper(parent, this.Value);
+			return new ObjectContainerHelper(parent, this.Value, false);
 		}
 
 		internal override void OnValueChanged(object oldValue, object newValue) {
@@ -81,12 +81,12 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid {
 			this.RaiseContainerHelperInvalidated();
 		}
 
-		protected override BindingBase CreateValueBinding() {
+		protected override BindingBase CreateValueBinding(bool dummyInstance) {
 			var selectedObject = this.SelectedObject;
 			var propertyName = this.PropertyDescriptor.Name;
 
 			//Bind the value property with the source object.
-			var binding = new Binding( propertyName )
+			var binding = new Binding( dummyInstance ? "Value" : propertyName )
 	  {
 				Source = this.GetValueInstance( selectedObject ),
 				Mode = PropertyDescriptor.IsReadOnly ? BindingMode.OneWay : BindingMode.TwoWay,

--- a/EditorLibraries/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinitionBase.cs
+++ b/EditorLibraries/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinitionBase.cs
@@ -112,7 +112,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid {
 		protected virtual void ResetValue() {
 		}
 
-		protected abstract BindingBase CreateValueBinding();
+		protected abstract BindingBase CreateValueBinding(bool dummyInstance);
 
 		#endregion
 
@@ -519,7 +519,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid {
 
 		#endregion //Value Property
 
-		public virtual void InitProperties() {
+		public virtual void InitProperties(bool dummyInstance) {
 			// Do "IsReadOnly" and PropertyName first since the others may need that value.
 			_isReadOnly = ComputeIsReadOnly();
 			_category = ComputeCategory();
@@ -538,7 +538,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid {
 			UpdateIsExpandable();
 			UpdateAdvanceOptions();
 
-			BindingBase valueBinding = this.CreateValueBinding();
+			BindingBase valueBinding = this.CreateValueBinding(dummyInstance);
 			BindingOperations.SetBinding(this, DescriptorPropertyDefinitionBase.ValueProperty, valueBinding);
 		}
 

--- a/EditorLibraries/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DummyInstance.cs
+++ b/EditorLibraries/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DummyInstance.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Xceed.Wpf.Toolkit.PropertyGrid {
+	public class DummyInstance : DependencyObject {
+		private PropertyDescriptor prop;
+		private object instance;
+
+		public DummyInstance(PropertyDescriptor prop, object instance) {
+			this.prop = prop;
+			this.instance = instance;
+			Value = prop.GetValue(instance);
+		}
+
+		public object Value {
+			get { return prop.GetValue(instance); }
+			set { prop.SetValue(instance, value); }
+		}
+	}
+}

--- a/EditorLibraries/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelper.cs
+++ b/EditorLibraries/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelper.cs
@@ -28,10 +28,12 @@ using Xceed.Wpf.Toolkit.PropertyGrid.Attributes;
 namespace Xceed.Wpf.Toolkit.PropertyGrid {
 	internal class ObjectContainerHelper : ObjectContainerHelperBase {
 		private object _selectedObject;
+		private bool _useDummyInstances;
 
-		public ObjectContainerHelper(IPropertyContainer propertyContainer, object selectedObject)
+		public ObjectContainerHelper(IPropertyContainer propertyContainer, object selectedObject, bool useDummyInstances)
 		  : base(propertyContainer) {
 			_selectedObject = selectedObject;
+			_useDummyInstances = useDummyInstances;
 		}
 
 		private object SelectedObject {
@@ -102,16 +104,19 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid {
 
 
 		private PropertyItem CreatePropertyItem(PropertyDescriptor property, PropertyDefinition propertyDef) {
+			object instance = SelectedObject;
+			if (_useDummyInstances)
+				instance = new DummyInstance(property, SelectedObject);
 			DescriptorPropertyDefinition definition = new DescriptorPropertyDefinition( property,
-																				  SelectedObject,
+																				  instance,
 																				  this.PropertyContainer.IsCategorized
 																				 );
-			definition.InitProperties();
+			definition.InitProperties(_useDummyInstances);
 
 			this.InitializeDescriptorDefinition(definition, propertyDef);
 			PropertyItem propertyItem = new PropertyItem( definition );
 			Debug.Assert(SelectedObject != null);
-			propertyItem.Instance = SelectedObject;
+			propertyItem.Instance = instance;
 			propertyItem.CategoryOrder = this.GetCategoryOrder(definition.CategoryValue);
 			propertyItem.WillRefreshPropertyGrid = this.GetWillRefreshPropertyGrid(property);
 			return propertyItem;

--- a/EditorLibraries/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelperBase.cs
+++ b/EditorLibraries/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelperBase.cs
@@ -426,6 +426,9 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid {
 				editorElement = editor.ResolveEditor(propertyItem);
 			}
 
+			if (pd.IsReadOnly)
+				editorElement.IsEnabled = false;
+
 			return editorElement;
 		}
 

--- a/EditorLibraries/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/PropertyGrid.cs
+++ b/EditorLibraries/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/PropertyGrid.cs
@@ -245,7 +245,31 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid {
 			UpdateContainerHelper();
 		}
 
-		#endregion //IsCategorized
+		#endregion //IsViewingEvents
+
+		#region UseDummyInstances
+
+		public static readonly DependencyProperty UseDummyInstancesProperty = DependencyProperty.Register( "UseDummyInstances", typeof( bool ), typeof( PropertyGrid ), new UIPropertyMetadata( false, OnUseDummyInstancesChanged ) );
+		public bool UseDummyInstances {
+			get {
+				return (bool) GetValue(UseDummyInstancesProperty);
+			}
+			set {
+				SetValue(UseDummyInstancesProperty, value);
+			}
+		}
+
+		private static void OnUseDummyInstancesChanged(DependencyObject o, DependencyPropertyChangedEventArgs e) {
+			PropertyGrid propertyGrid = o as PropertyGrid;
+			if (propertyGrid != null)
+				propertyGrid.OnUseDummyInstancesChanged((bool) e.OldValue, (bool) e.NewValue);
+		}
+
+		protected virtual void OnUseDummyInstancesChanged(bool oldValue, bool newValue) {
+			UpdateContainerHelper();
+		}
+
+		#endregion //UseDummyInstances
 
 		#region IsMiscCategoryLabelHidden
 
@@ -950,7 +974,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid {
 
 
 			if (SelectedObject != null) {
-				_containerHelper = new ObjectContainerHelper(this, SelectedObject);
+				_containerHelper = new ObjectContainerHelper(this, SelectedObject, UseDummyInstances);
 				((ObjectContainerHelper)_containerHelper).GenerateProperties();
 			}
 

--- a/EditorLibraries/Xceed.Wpf.Toolkit/Xceed.Wpf.Toolkit.csproj
+++ b/EditorLibraries/Xceed.Wpf.Toolkit/Xceed.Wpf.Toolkit.csproj
@@ -441,6 +441,7 @@
     <Compile Include="PropertyGrid\Implementation\CategoryGroupStyleSelector.cs" />
     <Compile Include="PropertyGrid\Implementation\Converters\IsDefaultCategoryConverter.cs" />
     <Compile Include="PropertyGrid\Implementation\Converters\IsStringEmptyConverter.cs" />
+    <Compile Include="PropertyGrid\Implementation\DummyInstance.cs" />
     <Compile Include="PropertyGrid\Implementation\Editors\CollectionEditor.cs" />
     <Compile Include="PropertyGrid\Implementation\Editors\SourceComboBoxEditor.cs" />
     <Compile Include="PropertyGrid\Implementation\TrimmedTextBlock.cs" />
@@ -789,6 +790,7 @@
     <Resource Include="PropertyGrid\Images\Events16.png" />
     <Resource Include="PropertyGrid\Images\Wrench16.png" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ZeldaOracle/Game/Common/Scripting/EventCollection.cs
+++ b/ZeldaOracle/Game/Common/Scripting/EventCollection.cs
@@ -175,8 +175,8 @@ namespace ZeldaOracle.Common.Scripting {
 					else {
 						oldEvent.Documentation.Name = newName;
 					}
-					events[newName] = oldEvent;
 					events.Remove(oldName);
+					events[newName] = oldEvent;
 				}
 				return true;
 			}

--- a/ZeldaOracle/Game/Common/Scripting/Properties.cs
+++ b/ZeldaOracle/Game/Common/Scripting/Properties.cs
@@ -89,6 +89,14 @@ namespace ZeldaOracle.Common.Scripting {
 			}
 		}
 
+		/// <summary>Get an enumerable list of all root base properties.</summary>
+		public IEnumerable<Property> GetRootProperties() {
+			foreach (Property property in RootProperties.map.Values) {
+				if (GetProperty(property.Name, true) == property)
+					yield return property;
+			}
+		}
+
 		/// <summary>Get the property with the given name.</summary>
 		public Property GetProperty(string name, bool acceptBaseProperties) {
 			Property property;
@@ -382,8 +390,8 @@ namespace ZeldaOracle.Common.Scripting {
 			Property p = GetProperty(oldName, false);
 			if (p != null && (!onlyIfNoBase || !p.HasBase)) {
 				p.Name = newName;
-				map[newName] = p;
 				map.Remove(oldName);
+				map[newName] = p;
 				if (baseProperties != null)
 					p.BaseProperty = baseProperties.GetProperty(newName, true);
 				else
@@ -585,8 +593,11 @@ namespace ZeldaOracle.Common.Scripting {
 				Property baseProperty = null;
 				if (baseProperties != null) {
 					baseProperty = baseProperties.GetProperty(name, true);
-					if (baseProperty != null && baseProperty.ObjectValue.Equals(value))
-						redundantValue = true;
+					if (baseProperty != null) {
+						if (baseProperty.ObjectValue.Equals(value))
+							redundantValue = true;
+					}
+					else { }
 				}
 
 				// Set the property value.
@@ -684,6 +695,15 @@ namespace ZeldaOracle.Common.Scripting {
 		public Properties BaseProperties {
 			get { return baseProperties; }
 			set { baseProperties = value; ConnectBaseProperties(); }
+		}
+
+		/// <summary>Gets the root base properties. Can be this.</summary>
+		public Properties RootProperties {
+			get {
+				if (baseProperties != null)
+					return baseProperties.RootProperties;
+				return this;
+			}
 		}
 
 		/// <summary>Returns true if the property collection has defined properties

--- a/ZeldaOracle/Game/Game/Worlds/WorldFile.cs
+++ b/ZeldaOracle/Game/Game/Worlds/WorldFile.cs
@@ -425,12 +425,15 @@ namespace ZeldaOracle.Game.Worlds {
 					if (!string.IsNullOrWhiteSpace(eventScriptID)) {
 						Script script = world.GetScript(eventScriptID);
 						Event evnt = events.GetEvent(eventName);
-						if (evnt == null)
+						if (evnt == null) {
 							evnt = new Event(eventName, script.Parameters.ToArray());
+							events.AddEvent(evnt);
+						}
 						if (script.IsHidden) {
 							events.GetEvent(eventName).Script = script;
 							// Assign the correct parameters
 							script.Parameters = evnt.Parameters;
+							// Hidden scripts are not stored in the manager while in the editor
 							world.RemoveScript(eventScriptID);
 						}
 						else {

--- a/ZeldaOracle/GameEditor/EditorWindow.xaml
+++ b/ZeldaOracle/GameEditor/EditorWindow.xaml
@@ -258,7 +258,7 @@
                         </DockPanel>-->
                     </Border>
                     <local:AirspaceGridSplitter Grid.Row="1" HorizontalAlignment="Stretch" ResizeDirection="Rows" ShowsPreview="True"/>
-                    <props:ZeldaPropertyGrid x:Name="propertyGrid" IsVirtualizing="True" Grid.Row="2" BorderThickness="1,1,0,1" BorderBrush="#FF828790" ShowTitle="False" ShowSearchBox="False" VirtualizingPanel.IsVirtualizing="True"/>
+                    <props:ZeldaPropertyGrid x:Name="propertyGrid" IsVirtualizing="True" Grid.Row="2" BorderThickness="1,1,0,1" BorderBrush="#FF828790" ShowTitle="False" ShowSearchBox="False" VirtualizingPanel.IsVirtualizing="True" UseDummyInstances="True"/>
                     <StackPanel Orientation="Horizontal" Grid.Row="2" VerticalAlignment="Top" Margin="116,9,0,0">
                         <Label Content="Editing:" Padding="0,0,5,0" FontWeight="Bold" Visibility="Collapsed"/>
                         <Grid Width="16" Height="16">

--- a/ZeldaOracle/GameEditor/PropertiesEditor/CustomEditors/EventPropertyEditor.cs
+++ b/ZeldaOracle/GameEditor/PropertiesEditor/CustomEditors/EventPropertyEditor.cs
@@ -69,6 +69,8 @@ namespace ZeldaEditor.PropertiesEditor.CustomEditors {
 
 			// Send a dummy value to update the control
 			SetValue("");
+			if (evnt.Script != null)
+				SetValue(EventDescriptor.GetValue(null) as string);
 		}
 	}
 }

--- a/ZeldaOracle/GameEditor/PropertiesEditor/CustomEventDescriptor.cs
+++ b/ZeldaOracle/GameEditor/PropertiesEditor/CustomEventDescriptor.cs
@@ -15,6 +15,7 @@ using ZeldaOracle.Common.Geometry;
 using ZeldaOracle.Common.Content;
 using ZeldaEditor.Control;
 using ZeldaOracle.Game.Worlds;
+using Xceed.Wpf.Toolkit.PropertyGrid;
 
 namespace ZeldaEditor.PropertiesEditor {
 
@@ -30,7 +31,7 @@ namespace ZeldaEditor.PropertiesEditor {
 		//-----------------------------------------------------------------------------
 
 		public CustomEventDescriptor(EditorControl editorControl, IEventObject eventObject, string eventName, EventCollection events, Attribute[] attributes) :
-			base(events.GetEvent(eventName).FinalReadableName, attributes) {
+			base(eventName, attributes) {
 			this.editorControl      = editorControl;
 			this.eventObject        = eventObject;
 			this.eventName			= eventName;
@@ -100,7 +101,7 @@ namespace ZeldaEditor.PropertiesEditor {
 		}
 
 		public override Type ComponentType {
-			get { return typeof(PropertiesContainer); }
+			get { return eventObject.GetType(); }
 		}
 
 		// Get the category this property should be listed under.
@@ -114,7 +115,7 @@ namespace ZeldaEditor.PropertiesEditor {
 		}
 
 		// Get the display name for the property.
-		public override string Name {
+		public override string DisplayName {
 			get { return Event.FinalReadableName; }
 		}
 

--- a/ZeldaOracle/GameEditor/PropertiesEditor/CustomPropertyDescriptor.cs
+++ b/ZeldaOracle/GameEditor/PropertiesEditor/CustomPropertyDescriptor.cs
@@ -14,6 +14,7 @@ using ZeldaOracle.Common.Graphics;
 using ZeldaOracle.Common.Geometry;
 using ZeldaOracle.Common.Content;
 using ZeldaEditor.Control;
+using Xceed.Wpf.Toolkit.PropertyGrid;
 
 namespace ZeldaEditor.PropertiesEditor {
 	
@@ -29,7 +30,7 @@ namespace ZeldaEditor.PropertiesEditor {
 		//-----------------------------------------------------------------------------
 
 		public CustomPropertyDescriptor(EditorControl editorControl, IPropertyObject propertyObject, string propertyName, Properties modifiedProperties, Attribute[] attributes) :
-			base(modifiedProperties.GetProperty(propertyName, true).FinalReadableName, attributes)
+			base(propertyName, attributes)
 		{
 			this.editorControl      = editorControl;
 			this.propertyObject     = propertyObject;
@@ -100,7 +101,7 @@ namespace ZeldaEditor.PropertiesEditor {
 		}
 
 		public override Type ComponentType {
-			get { return typeof(PropertiesContainer); }
+			get { return propertyObject.GetType(); }
 		}
 
 		// Get the category this property should be listed under.
@@ -114,10 +115,10 @@ namespace ZeldaEditor.PropertiesEditor {
 		}
 
 		// Get the display name for the property.
-		public override string Name {
+		public override string DisplayName {
 			get { return Property.FinalReadableName; }
 		}
-			
+
 		public override Type PropertyType {
 			get { return Property.PropertyTypeToType(Property.Type); }
 		}

--- a/ZeldaOracle/GameEditor/PropertiesEditor/ZeldaPropertyGrid.cs
+++ b/ZeldaOracle/GameEditor/PropertiesEditor/ZeldaPropertyGrid.cs
@@ -11,7 +11,6 @@ using System.Windows.Input;
 using Xceed.Wpf.Toolkit.PropertyGrid;
 using Xceed.Wpf.Toolkit.PropertyGrid.Editors;
 using ZeldaEditor.Control;
-using ZeldaEditor.PropertiesEditor.CustomEditors;
 using ZeldaEditor.Undo;
 using ZeldaEditor.Windows;
 using ZeldaEditor.WinForms;
@@ -24,10 +23,9 @@ namespace ZeldaEditor.PropertiesEditor {
 	public class ZeldaPropertyGrid : PropertyGrid {
 
 		private EditorControl editorControl;
-		private IPropertyObject propertyObject;
-		private PropertiesContainer propertiesContainer;
+		private static IPropertyObject propertyObject;
+		//private PropertiesContainer propertiesContainer;
 		private WpfFocusMessageFilter messageFilter;
-
 
 		//-----------------------------------------------------------------------------
 		// Constructor
@@ -36,9 +34,9 @@ namespace ZeldaEditor.PropertiesEditor {
 		public ZeldaPropertyGrid() {
 			editorControl		= null;
 			propertyObject		= null;
-			propertiesContainer	= new PropertiesContainer(this);
+			//propertiesContainer = null;// new PropertiesContainer(this);
 
-			this.SelectedObject			= propertiesContainer;
+			//this.SelectedObject			= propertiesContainer;
 			this.PropertyValueChanged	+= OnPropertyChange;
 			this.IsMiscCategoryLabelHidden = false;
 			this.ShowAdvancedOptions	= false;
@@ -59,32 +57,29 @@ namespace ZeldaEditor.PropertiesEditor {
 		// Properties Methods
 		//-----------------------------------------------------------------------------
 
-		public void OpenProperties(IPropertyObject propertyObject) {
-			if (propertyObject != this.propertyObject) {
+		public void OpenProperties(IPropertyObject propObject) {
+			if (propObject != propertyObject) {
 				editorControl.EditorWindow.UpdatePropertyPreview(propertyObject);
-				this.propertyObject = propertyObject;
-				EventCollection events = null;
-				if (propertyObject is IEventObject) {
-					events = (propertyObject as IEventObject).Events;
-				}
-				propertiesContainer.Set(propertyObject.Properties, events);
-				UpdateContainerHelper();
+				propertyObject = propObject;
+				SelectedObject = new PropertiesContainer(this, propertyObject);
 			}
 		}
 
 		public void UpdateProperties() {
-			Update();
+			if (SelectedObject != null)
+				Update();
 		}
 
 		public void RefreshProperties() {
-			UpdateContainerHelper();
+			if (SelectedObject != null) {
+				SelectedObject = new PropertiesContainer(this, propertyObject);
+			}
 		}
 
 		public void CloseProperties() {
 			if (propertyObject != null) {
 				propertyObject = null;
-				propertiesContainer.Clear();
-				UpdateContainerHelper();
+				SelectedObject = new PropertiesContainer(this, null);
 				editorControl.EditorWindow.UpdatePropertyPreview(propertyObject);
 			}
 		}

--- a/ZeldaOracle/GameEditor/Windows/RefactorWindow.xaml.cs
+++ b/ZeldaOracle/GameEditor/Windows/RefactorWindow.xaml.cs
@@ -196,6 +196,8 @@ namespace ZeldaEditor.Windows {
 			if (count > 0) {
 				editorControl.PopToOriginalAction();
 				editorControl.PropertyGrid.RefreshProperties();
+				editorControl.IsModified = true;
+				needsToSearch = true;
 			}
 		}
 


### PR DESCRIPTION
* Fixed crashes and bugs with Refactor Window.
* In general, property descriptors no longer linger forever.
* Refactor window now updates count again after executing.
* Refactoring now marks the world as modified.
* Read only property editors are now proeprty properly.