### PR TITLE
Fix PrettyBin build errors caused by vshost

### DIFF
--- a/ZeldaOracle/ConscriptDesigner/ConscriptDesigner.csproj
+++ b/ZeldaOracle/ConscriptDesigner/ConscriptDesigner.csproj
@@ -527,6 +527,6 @@
     <ItemGroup>
       <MoveToLibFolder Include="$(OutputPath)*.dll ; $(OutputPath)*.pdb ; $(OutputPath)*.xml" />
     </ItemGroup>
-    <Move SourceFiles="@(MoveToLibFolder)" DestinationFolder="$(OutputPath)lib" OverwriteReadOnlyFiles="true" />
+    <Move SourceFiles="@(MoveToLibFolder)" DestinationFolder="$(OutputPath)lib" OverwriteReadOnlyFiles="true" ContinueOnError="WarnAndContinue"/>
   </Target>
 </Project>

--- a/ZeldaOracle/Game/Zelda.csproj
+++ b/ZeldaOracle/Game/Zelda.csproj
@@ -698,6 +698,6 @@
     <ItemGroup>
       <MoveToLibFolder Include="$(OutputPath)*.dll ; $(OutputPath)*.pdb ; $(OutputPath)*.xml" />
     </ItemGroup>
-    <Move SourceFiles="@(MoveToLibFolder)" DestinationFolder="$(OutputPath)lib" OverwriteReadOnlyFiles="true" />
+    <Move SourceFiles="@(MoveToLibFolder)" DestinationFolder="$(OutputPath)lib" OverwriteReadOnlyFiles="true" ContinueOnError="WarnAndContinue"/>
   </Target>
 </Project>

--- a/ZeldaOracle/GameEditor/ZeldaEditor.csproj
+++ b/ZeldaOracle/GameEditor/ZeldaEditor.csproj
@@ -696,6 +696,6 @@
     <ItemGroup>
       <MoveToLibFolder Include="$(OutputPath)*.dll ; $(OutputPath)*.pdb ; $(OutputPath)*.xml" />
     </ItemGroup>
-    <Move SourceFiles="@(MoveToLibFolder)" DestinationFolder="$(OutputPath)lib" OverwriteReadOnlyFiles="true" />
+    <Move SourceFiles="@(MoveToLibFolder)" DestinationFolder="$(OutputPath)lib" OverwriteReadOnlyFiles="true" ContinueOnError="WarnAndContinue"/>
   </Target>
 </Project>


### PR DESCRIPTION
* Added `ContinueOnError="WarnAndContinue"` to PrettyBin build tasks to
fix vshost hogging dlls.