### PR TITLE
Fix Seed Burning and Reward Visibility

### DIFF
--- a/ZeldaOracle/Game/Common/Scripts/CustomReaders/RewardSR.cs
+++ b/ZeldaOracle/Game/Common/Scripts/CustomReaders/RewardSR.cs
@@ -108,6 +108,12 @@ namespace ZeldaOracle.Common.Scripts.CustomReaders {
 				rewardData.CantCollectMessage = parameters.GetString(0);
 			});
 			//=====================================================================================
+			AddCommand("FULL", (int) Modes.Reward,
+				"string fullMessage",
+			delegate (CommandParam parameters) {
+				rewardData.FullMessage = parameters.GetString(0);
+			});
+			//=====================================================================================
 			AddCommand("HOLDINCHEST", (int) Modes.Reward,
 				"bool cantCollectMessage",
 			delegate (CommandParam parameters) {
@@ -147,15 +153,6 @@ namespace ZeldaOracle.Common.Scripts.CustomReaders {
 					ThrowCommandParseError("Can only call AMOUNT when constructing a " +
 						"RewardAmount!");
 				rewardData.Amount = parameters.GetInt(0);
-			});
-			//=====================================================================================
-			AddCommand("FULL", (int) Modes.Reward,
-				"string fullMessage",
-			delegate (CommandParam parameters) {
-				if (!TypeHelper.TypeHasBase<RewardAmount>(rewardData.Type))
-					ThrowCommandParseError("Can only call FULL when constructing a " +
-						"RewardAmount!");
-				rewardData.FullMessage = parameters.GetString(0);
 			});
 			//=====================================================================================
 			// AMMO REWARD BUILDING

--- a/ZeldaOracle/Game/Common/Util/XnaCasting.cs
+++ b/ZeldaOracle/Game/Common/Util/XnaCasting.cs
@@ -20,7 +20,7 @@ namespace ZeldaOracle.Common.Util {
 			return new XnaColor(color.R, color.G, color.B, color.A);
 		}
 
-		/// <summary>Casts the Zelda Color to an Xna Color.</summary>
+		/// <summary>Casts the Zelda Color to an Xna Vector4.</summary>
 		public static XnaVector4 ToXnaVector4(this Color color) {
 			return new XnaVector4(color.RF, color.GF, color.BF, color.AF);
 		}
@@ -28,6 +28,11 @@ namespace ZeldaOracle.Common.Util {
 		/// <summary>Casts the Xna Color to a Zelda Color.</summary>
 		public static Color ToColor(this XnaColor color) {
 			return new Color(color.R, color.G, color.B, color.A);
+		}
+
+		/// <summary>Casts the Xna Vector4 to a Zelda Color.</summary>
+		public static Color ToColor(this XnaVector4 vector) {
+			return new Color(vector.X, vector.Y, vector.Z, vector.W);
 		}
 
 

--- a/ZeldaOracle/Game/Common/Util/XnaExtensions.cs
+++ b/ZeldaOracle/Game/Common/Util/XnaExtensions.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace ZeldaOracle.Common.Util {
-	/// <summary>A static class for XNA Extensions.</summary>
+	/// <summary>A static class for Xna Extensions.</summary>
 	public static class XnaExtensions {
 
 		/// <summary>Gets the current render target for the graphics device.</summary>

--- a/ZeldaOracle/Game/Game/Entities/Collectibles/CollectibleReward.cs
+++ b/ZeldaOracle/Game/Game/Entities/Collectibles/CollectibleReward.cs
@@ -68,10 +68,12 @@ namespace ZeldaOracle.Game.Entities {
 			if (!submerged || RoomControl.Player.IsSubmerged) {
 				if (showMessage || submerged) {
 					if (submerged) {
-						RoomControl.SpawnEntity(new Effect(GameData.ANIM_EFFECT_WATER_SPLASH,
+						RoomControl.SpawnEntity(new Effect(
+							GameData.ANIM_EFFECT_WATER_SPLASH,
 							DepthLayer.EffectSplash, true), position);
 					}
-					RoomControl.GameControl.PushRoomState(new RoomStateReward(reward));
+					RoomControl.GameControl.PushRoomState(
+						new RoomStateReward(reward, this));
 				}
 				else {
 					reward.OnCollectNoMessage();

--- a/ZeldaOracle/Game/Game/Entities/Projectiles/Seeds/SeedProjectile.cs
+++ b/ZeldaOracle/Game/Game/Entities/Projectiles/Seeds/SeedProjectile.cs
@@ -151,7 +151,17 @@ namespace ZeldaOracle.Game.Entities.Projectiles.Seeds {
 
 		public override void OnCollideSolid(Collision collision) {
 			bool absorbSeeds = (collision.IsTile &&
-				collision.Tile.Flags.HasFlag(TileFlags.AbsorbSeeds));
+				(collision.Tile.Flags.HasFlag(TileFlags.AbsorbSeeds) ||
+				(collision.Tile.Flags.HasFlag(TileFlags.Burnable) &&
+				SeedType == SeedType.Ember)));
+
+			// TODO: Fix this not triggering in base.Update
+			Tile tile = collision.Tile;
+			if (tile != null) {
+				tile.OnHitByProjectile(this);
+				if (IsDestroyed)
+					return;
+			}
 
 			// Keep track of number of rebounds
 			if (reboundOffWalls && collision.IsResolved && !absorbSeeds) {

--- a/ZeldaOracle/Game/Game/GameStates/RoomStates/RoomStateReward.cs
+++ b/ZeldaOracle/Game/Game/GameStates/RoomStates/RoomStateReward.cs
@@ -7,6 +7,7 @@ using ZeldaOracle.Common.Content;
 using ZeldaOracle.Common.Geometry;
 using ZeldaOracle.Common.Graphics;
 using ZeldaOracle.Game.Control;
+using ZeldaOracle.Game.Entities;
 using ZeldaOracle.Game.Entities.Players.States;
 using ZeldaOracle.Game.Items;
 using ZeldaOracle.Game.Items.Rewards;
@@ -14,7 +15,20 @@ using ZeldaOracle.Game.Items.Rewards;
 namespace ZeldaOracle.Game.GameStates.RoomStates {
 	public class RoomStateReward : RoomState {
 
+		//-----------------------------------------------------------------------------
+		// Constants
+		//-----------------------------------------------------------------------------
+
+		private const int CHEST_DURATION = 32;
+		private const int HOLD_DURATION = 6;
+
+
+		//-----------------------------------------------------------------------------
+		// Members
+		//-----------------------------------------------------------------------------
+
 		private Reward reward;
+		private Entity entity;
 		private Point2I chestPosition;
 		private int timer;
 		private bool useChest;
@@ -23,19 +37,14 @@ namespace ZeldaOracle.Game.GameStates.RoomStates {
 
 
 		//-----------------------------------------------------------------------------
-		// Constants
-		//-----------------------------------------------------------------------------
-
-		private const int RaiseDuration = 32;
-		private const int NonChestDuration = 6;
-
-
-		//-----------------------------------------------------------------------------
 		// Constructor
 		//-----------------------------------------------------------------------------
 
-		public RoomStateReward(Reward reward, Action completeAction = null) {
+		public RoomStateReward(Reward reward, Entity entity,
+			Action completeAction = null)
+		{
 			this.reward				= reward;
+			this.entity				= entity;
 			this.completeAction		= completeAction;
 			this.updateRoom			= false;
 			this.animateRoom		= true;
@@ -44,9 +53,14 @@ namespace ZeldaOracle.Game.GameStates.RoomStates {
 			this.timer				= 0;
 			this.animationPlayer	= new AnimationPlayer();
 		}
+		
+		public RoomStateReward(Reward reward, Action completeAction = null) 
+			: this(reward, null, completeAction)
+		{
+		}
 
-		public RoomStateReward(Reward reward, Point2I chestPosition) :
-			this(reward, null)
+		public RoomStateReward(Reward reward, Point2I chestPosition)
+			: this(reward, null, null)
 		{
 			this.chestPosition		= chestPosition;
 			this.useChest			= true;
@@ -54,21 +68,22 @@ namespace ZeldaOracle.Game.GameStates.RoomStates {
 
 
 		//-----------------------------------------------------------------------------
-		// Overridden methods
+		// Override Methods
 		//-----------------------------------------------------------------------------
 
 		public override void OnBegin() {
 			animationPlayer.Play(reward.Sprite);
 			timer = -1;
+			if (entity != null)
+				entity.Graphics.IsVisible = false;
 		}
 
 		public override void Update() {
 			animationPlayer.Update();
 			timer++;
-			if (timer == (useChest ? RaiseDuration : NonChestDuration)) {
+			if (timer == Duration) {
 				AudioSystem.PlaySound(GameData.SOUND_FANFARE_ITEM);
 				reward.OnDisplayMessage();
-				//GameControl.DisplayMessage(new Message(reward.Message));
 
 				if (reward.HoldType == RewardHoldTypes.OneHand) {
 					GameControl.Player.BeginBusyState(1);
@@ -79,7 +94,7 @@ namespace ZeldaOracle.Game.GameStates.RoomStates {
 					GameControl.Player.Graphics.PlayAnimation(GameData.ANIM_PLAYER_RAISE_TWO_HANDS);
 				}
 			}
-			else if (timer == (useChest ? RaiseDuration : NonChestDuration) + 1) {
+			else if (timer == Duration + 1) {
 				// Pop before incase the OnCollect pushes a new game state
 				gameControl.PopRoomState();
 				reward.OnCollect();
@@ -90,12 +105,12 @@ namespace ZeldaOracle.Game.GameStates.RoomStates {
 
 		public override void Draw(Graphics2D g) {
 			g.PushTranslation(0, GameSettings.HUD_HEIGHT);
-			g.PushTranslation(-RoomControl.ViewControl.Camera.TopLeft);
+			g.PushTranslation(-GameUtil.Bias(RoomControl.ViewControl.Camera.TopLeft));
 
 			if (!reward.HoldInChest && useChest) {
 				g.DrawAnimation(animationPlayer, chestPosition + new Point2I(0, -8 - (timer + 2) / 4));
 			}
-			else if (timer >= (useChest ? RaiseDuration : NonChestDuration)) {
+			else if (timer >= Duration) {
 				if (reward.HoldType == RewardHoldTypes.TwoHands) {
 					g.DrawAnimation(animationPlayer, GameControl.Player.Center + new Point2I(-8, -23));
 				}
@@ -105,6 +120,15 @@ namespace ZeldaOracle.Game.GameStates.RoomStates {
 			}
 
 			g.PopTranslation(2);
+		}
+
+
+		//-----------------------------------------------------------------------------
+		// Properties
+		//-----------------------------------------------------------------------------
+
+		public int Duration {
+			get { return (useChest ? CHEST_DURATION : HOLD_DURATION); }
 		}
 
 		public Action CompleteAction {

--- a/ZeldaOracle/Game/Game/Items/Rewards/Reward.cs
+++ b/ZeldaOracle/Game/Game/Items/Rewards/Reward.cs
@@ -25,6 +25,9 @@ namespace ZeldaOracle.Game.Items.Rewards {
 		private string			message;
 		private string			obtainMessage;
 		private string			cantCollectMessage;
+		/// <summary>The message displayed when the cannot be carried because the
+		/// container is full.</summary>
+		private string fullMessage;
 		private bool			holdInChest;
 		private RewardHoldTypes	holdType;
 		private bool			hasDuration;
@@ -47,6 +50,7 @@ namespace ZeldaOracle.Game.Items.Rewards {
 			message				= "";
 			obtainMessage		= "";
 			cantCollectMessage	= "";
+			fullMessage			= "";
 			holdInChest			= true;
 			holdType			= RewardHoldTypes.TwoHands;
 			hasDuration			= false;
@@ -77,6 +81,7 @@ namespace ZeldaOracle.Game.Items.Rewards {
 			reward.message				= data.Message;
 			reward.obtainMessage		= data.ObtainMessage;
 			reward.cantCollectMessage	= data.CantCollectMessage;
+			reward.fullMessage			= data.FullMessage;
 			reward.holdInChest			= data.HoldInChest;
 			reward.holdType				= data.HoldType;
 			reward.hasDuration			= data.HasDuration;
@@ -130,13 +135,20 @@ namespace ZeldaOracle.Game.Items.Rewards {
 			get { return true; }
 		}
 
+		/// <summary>Gets if the reward is already at capacity.</summary>
+		public virtual bool IsFull {
+			get { return false; }
+		}
+
 		/// <summary>Gets the appropriate message to display when collecting the
 		/// reward.</summary>
 		public virtual string AppropriateMessage {
 			get {
 				string text = message;
 				if (!CanCollect && !string.IsNullOrWhiteSpace(CantCollectMessage))
-					text = CantCollectMessage;
+					text += "<p>" + CantCollectMessage;
+				else if (IsFull && !string.IsNullOrWhiteSpace(FullMessage))
+					text += "<p>" + FullMessage;
 				return text;
 			}
 		}
@@ -225,6 +237,12 @@ namespace ZeldaOracle.Game.Items.Rewards {
 		public string CantCollectMessage {
 			get { return cantCollectMessage; }
 			set { cantCollectMessage = value; }
+		}
+
+		/// <summary>Gets the message displayed when the reward is already at capacity.</summary>
+		public string FullMessage {
+			get { return fullMessage; }
+			set { fullMessage = value; }
 		}
 
 		/// <summary>Gets if the reward does not rise out of chests and instead, is

--- a/ZeldaOracle/Game/Game/Items/Rewards/RewardAmount.cs
+++ b/ZeldaOracle/Game/Game/Items/Rewards/RewardAmount.cs
@@ -11,9 +11,6 @@ namespace ZeldaOracle.Game.Items.Rewards {
 		
 		/// <summary>The amount of the reward to give.</summary>
 		private int amount;
-		/// <summary>The message displayed when the cannot be carried because the
-		/// container is full.</summary>
-		private string fullMessage;
 
 
 		//-----------------------------------------------------------------------------
@@ -23,30 +20,6 @@ namespace ZeldaOracle.Game.Items.Rewards {
 		/// <summary>Constructs an amount reward.</summary>
 		public RewardAmount() {
 			amount			= 0;
-			fullMessage		= "";
-		}
-
-
-		//-----------------------------------------------------------------------------
-		// Virtual Properties
-		//-----------------------------------------------------------------------------
-
-		/// <summary>Gets if the reward is already at capacity.</summary>
-		public virtual bool IsFull {
-			get { return false; }
-		}
-
-		/// <summary>Gets the appropriate message to display when collecting the
-		/// reward.</summary>
-		public override string AppropriateMessage {
-			get {
-				string text = Message;
-				if (!CanCollect && !string.IsNullOrWhiteSpace(CantCollectMessage))
-					text = CantCollectMessage;
-				else if (IsFull && !string.IsNullOrWhiteSpace(FullMessage))
-					text = FullMessage;
-				return text;
-			}
 		}
 
 
@@ -56,7 +29,6 @@ namespace ZeldaOracle.Game.Items.Rewards {
 		
 		/// <summary>Called when the reward is being initialized.</summary>
 		protected override void OnInitialize() {
-			FullMessage			= RewardData.FullMessage;
 			Amount				= RewardData.Amount;
 		}
 
@@ -83,12 +55,6 @@ namespace ZeldaOracle.Game.Items.Rewards {
 		public int Amount {
 			get { return amount; }
 			set { amount = value; }
-		}
-
-		/// <summary>Gets the message displayed when the reward is already at capacity.</summary>
-		public string FullMessage {
-			get { return fullMessage; }
-			set { fullMessage = value; }
 		}
 	}
 }

--- a/ZeldaOracle/Game/Game/Items/Rewards/RewardItem.cs
+++ b/ZeldaOracle/Game/Game/Items/Rewards/RewardItem.cs
@@ -44,6 +44,7 @@ namespace ZeldaOracle.Game.Items.Rewards {
 		/// <summary>Called when the player collects the reward.</summary>
 		public override void OnCollect() {
 			Inventory.ObtainItem(item);
+			item.IsLost = false;
 			// Don't level-down the item
 			item.Level = GMath.Max(item.Level, level);
 		}

--- a/ZeldaOracle/Game/Game/Tiles/Custom/TileChest.cs
+++ b/ZeldaOracle/Game/Game/Tiles/Custom/TileChest.cs
@@ -22,9 +22,21 @@ namespace ZeldaOracle.Game.Tiles.Custom {
 
 
 		//-----------------------------------------------------------------------------
+		// Mutators
+		//-----------------------------------------------------------------------------
+
+		/// <summary>Closes and the chest and allows looting again.</summary>
+		public void Close() {
+			IsLooted = false;
+			AudioSystem.PlaySound(GameData.SOUND_CHEST_OPEN);
+			Graphics.PlayAnimation(SpriteList[0]);
+		}
+
+
+		//-----------------------------------------------------------------------------
 		// Overridden methods
 		//-----------------------------------------------------------------------------
-		
+
 		// Called when the player presses A on this tile, when facing the given direction.
 		public override bool OnAction(Direction direction) {
 			if (!IsLooted) {


### PR DESCRIPTION
* Ember seeds now properly burn burnable tiles instead of bouncing
first.
* All seeds trigger OnProjectileHit again. TODO: Hackishly fixed, find
way to trigger it in proper location.
* Reward entities now disappear during the pause when the Reward state
begins.