### PR TITLE
Disposal/Image/RenderTarget Additions

### DIFF
--- a/ZeldaOracle/ConscriptDesigner/WinForms/ZeldaGraphicsDeviceControl.cs
+++ b/ZeldaOracle/ConscriptDesigner/WinForms/ZeldaGraphicsDeviceControl.cs
@@ -16,7 +16,7 @@ namespace ConscriptDesigner.WinForms {
 	public class ZeldaGraphicsDeviceControl : TimersGraphicsDeviceControl {
 		
 		// Static
-		private static RenderTarget2D renderTarget;
+		private static RenderTarget renderTarget;
 		private static Zone defaultZone;
 		
 		protected int columns;
@@ -53,7 +53,7 @@ namespace ConscriptDesigner.WinForms {
 
 		protected override void Initialize() {
 			if (renderTarget == null)
-				renderTarget = new RenderTarget2D(GraphicsDevice, 1, 1);
+				renderTarget = new RenderTarget(Point2I.One, false);
 			if (defaultZone == null)
 				defaultZone = new Zone();
 
@@ -127,12 +127,8 @@ namespace ConscriptDesigner.WinForms {
 
 		private void OnPostReset(object sender, EventArgs e) {
 			if (isInitialized) {
-				Point2I oldRenderTargetSize = new Point2I(renderTarget.Width, renderTarget.Height);
-				Point2I newRenderTargetSize = GMath.Max(oldRenderTargetSize, ClientSize);
-				if (newRenderTargetSize != oldRenderTargetSize) {
-					renderTarget.Dispose();
-					renderTarget = new RenderTarget2D(GraphicsDevice, newRenderTargetSize.X, newRenderTargetSize.Y);
-				}
+				Point2I newSize = GMath.Max(renderTarget.Size, ClientSize);
+				renderTarget.Resize(newSize);
 				ScrollPosition = Point2I.Zero;
 			}
 		}

--- a/ZeldaOracle/ConscriptDesigner/WinForms/ZeldaUniqueGraphicsControl.cs
+++ b/ZeldaOracle/ConscriptDesigner/WinForms/ZeldaUniqueGraphicsControl.cs
@@ -15,7 +15,7 @@ namespace ConscriptDesigner.WinForms {
 	public class ZeldaUniqueGraphicsDeviceControl : TimersGraphicsDeviceControl {
 
 		// Static
-		private static RenderTarget2D renderTarget;
+		private static RenderTarget renderTarget;
 		private static Zone defaultZone;
 
 		protected int columns;
@@ -59,7 +59,7 @@ namespace ConscriptDesigner.WinForms {
 
 		protected override void Initialize() {
 			if (renderTarget == null)
-				renderTarget = new RenderTarget2D(GraphicsDevice, 1, 1);
+				renderTarget = new RenderTarget(Point2I.One, false);
 			if (defaultZone == null)
 				defaultZone = new Zone();
 
@@ -123,12 +123,8 @@ namespace ConscriptDesigner.WinForms {
 
 		private void OnPostReset(object sender, EventArgs e) {
 			if (isInitialized) {
-				Point2I oldRenderTargetSize = new Point2I(renderTarget.Width, renderTarget.Height);
-				Point2I newRenderTargetSize = GMath.Max(oldRenderTargetSize, UnscaledClientSize);
-				if (newRenderTargetSize != oldRenderTargetSize) {
-					renderTarget.Dispose();
-					renderTarget = new RenderTarget2D(GraphicsDevice, newRenderTargetSize.X, newRenderTargetSize.Y);
-				}
+				Point2I newSize = GMath.Max(renderTarget.Size, ClientSize);
+				renderTarget.Resize(newSize);
 				ScrollPosition = Point2I.Zero;
 			}
 		}

--- a/ZeldaOracle/Game/Common/Content/Resources.cs
+++ b/ZeldaOracle/Game/Common/Content/Resources.cs
@@ -195,6 +195,8 @@ namespace ZeldaOracle.Common.Content {
 				resource.Dispose();
 			}
 			independentResources.Clear();
+
+			Unmapping.Dispose();
 		}
 
 		/*/// <summary>Adds an indenpendent resource that will be disposed

--- a/ZeldaOracle/Game/Common/Graphics/Graphics2D.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Graphics2D.cs
@@ -680,12 +680,12 @@ namespace ZeldaOracle.Common.Graphics {
 
 		/// <summary>Gets the current render target.</summary>
 		public RenderTarget GetRenderTarget() {
-			return RenderTarget.Wrap(GraphicsDevice.GetRenderTarget());
+			return GraphicsDevice.GetRenderTarget();
 		}
 
 		/// <summary>Sets the render target to draw to.</summary>
 		public void SetRenderTarget(RenderTarget2D renderTarget) {
-			spriteBatch.GraphicsDevice.SetRenderTarget(renderTarget);
+			GraphicsDevice.SetRenderTarget(renderTarget);
 		}
 
 

--- a/ZeldaOracle/Game/Common/Graphics/Shaders/SineShiftShader.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Shaders/SineShiftShader.cs
@@ -34,7 +34,7 @@ namespace ZeldaOracle.Common.Graphics.Shaders {
 		public override void ApplyParameters() {
 			Color color = background.UnmappedColorSafe;
 			Parameters["Background"].SetValue(color.ToXnaVector4());
-			RenderTarget target = RenderTarget.Wrap(GraphicsDevice.GetRenderTarget());
+			RenderTarget target = GraphicsDevice.GetRenderTarget();
 			Parameters["TargetSize"].SetValue(target.Size.ToXnaVector2());
 		}
 

--- a/ZeldaOracle/Game/Common/Graphics/Unmapping.cs
+++ b/ZeldaOracle/Game/Common/Graphics/Unmapping.cs
@@ -1,17 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;
-using ZeldaOracle.Common.Content;
 using ZeldaOracle.Common.Geometry;
 using ZeldaOracle.Common.Graphics.Shaders;
 using ZeldaOracle.Common.Graphics.Sprites;
 using ZeldaOracle.Game;
 
 namespace ZeldaOracle.Common.Graphics {
-	
 	/// <summary>A structured used to lookup already-unmapped unmapped sprites.</summary>
 	public struct UnmappedSpriteLookup {
 		/// <summary>The sprite parts this unmapped sprite is made of.</summary>
@@ -28,18 +22,22 @@ namespace ZeldaOracle.Common.Graphics {
 
 		/// <summary>Constructs an unmapped sprite lookup from the specified sprite,
 		/// settings, and palettes.</summary>
-		public UnmappedSpriteLookup(ISprite sprite, SpriteSettings settings, Palette tilePalette, Palette entityPalette) {
-			this.SpriteParts	= sprite.GetParts(settings);
-			this.TilePalette	= tilePalette;
-			this.EntityPalette	= entityPalette;
+		public UnmappedSpriteLookup(ISprite sprite, SpriteSettings settings,
+			Palette tilePalette, Palette entityPalette)
+		{
+			SpriteParts		= sprite.GetParts(settings);
+			TilePalette		= tilePalette;
+			EntityPalette	= entityPalette;
 		}
 
 		/// <summary>Constructs an unmapped sprite lookup from the specified sprite parts
 		/// and palettes.</summary>
-		public UnmappedSpriteLookup(SpritePart spriteParts, Palette tilePalette, Palette entityPalette) {
-			this.SpriteParts    = spriteParts;
-			this.TilePalette    = tilePalette;
-			this.EntityPalette  = entityPalette;
+		public UnmappedSpriteLookup(SpritePart spriteParts, Palette tilePalette,
+			Palette entityPalette)
+		{
+			SpriteParts		= spriteParts;
+			TilePalette		= tilePalette;
+			EntityPalette	= entityPalette;
 		}
 
 
@@ -104,44 +102,74 @@ namespace ZeldaOracle.Common.Graphics {
 
 
 		//-----------------------------------------------------------------------------
+		// Disposing
+		//-----------------------------------------------------------------------------
+
+		/// <summary>Disposes of all unmapped sprites.</summary>
+		public static void Dispose() {
+			foreach (var pair in unmappedSprites) {
+				pair.Value.Image.Dispose();
+			}
+			unmappedSprites.Clear();
+		}
+
+
+		//-----------------------------------------------------------------------------
 		// Unmapping
 		//-----------------------------------------------------------------------------
 
 		/// <summary>Unmaps the specified sprite.</summary>
 		public static UnmappedSprite UnmapSprite(Graphics2D g, ISprite sprite) {
-			return UnmapSprite(g, sprite, SpriteSettings.Default, GameData.PAL_TILES_DEFAULT, GameData.PAL_ENTITIES_DEFAULT);
+			return UnmapSprite(g, sprite, SpriteSettings.Default,
+				GameData.PAL_TILES_DEFAULT, GameData.PAL_ENTITIES_DEFAULT);
 		}
 
 		/// <summary>Unmaps the specified sprite.</summary>
-		public static UnmappedSprite UnmapSprite(Graphics2D g, ISprite sprite, SpriteSettings settings) {
-			return UnmapSprite(g, sprite, settings, GameData.PAL_TILES_DEFAULT, GameData.PAL_ENTITIES_DEFAULT);
+		public static UnmappedSprite UnmapSprite(Graphics2D g, ISprite sprite,
+			SpriteSettings settings)
+		{
+			return UnmapSprite(g, sprite, settings, GameData.PAL_TILES_DEFAULT,
+				GameData.PAL_ENTITIES_DEFAULT);
 		}
 
 		/// <summary>Unmaps the specified sprite.</summary>
-		public static UnmappedSprite UnmapSprite(Graphics2D g, ISprite sprite, Palette tilePalette, Palette entityPalette) {
-			return UnmapSprite(g, sprite, SpriteSettings.Default, tilePalette, entityPalette);
+		public static UnmappedSprite UnmapSprite(Graphics2D g, ISprite sprite,
+			Palette tilePalette, Palette entityPalette)
+		{
+			return UnmapSprite(g, sprite, SpriteSettings.Default, tilePalette,
+				entityPalette);
 		}
 
 		/// <summary>Unmaps the specified sprite.</summary>
-		public static UnmappedSprite UnmapSprite(Graphics2D g, ISprite sprite, PaletteShader shader) {
-			return UnmapSprite(g, sprite, SpriteSettings.Default, shader.TilePalette, shader.EntityPalette);
+		public static UnmappedSprite UnmapSprite(Graphics2D g, ISprite sprite,
+			PaletteShader shader)
+		{
+			return UnmapSprite(g, sprite, SpriteSettings.Default, shader.TilePalette,
+				shader.EntityPalette);
 		}
 
 		/// <summary>Unmaps the specified sprite.</summary>
-		public static UnmappedSprite UnmapSprite(Graphics2D g, ISprite sprite, SpriteSettings settings, PaletteShader shader) {
-			return UnmapSprite(g, sprite, settings, shader.TilePalette, shader.EntityPalette);
+		public static UnmappedSprite UnmapSprite(Graphics2D g, ISprite sprite,
+			SpriteSettings settings, PaletteShader shader)
+			{
+			return UnmapSprite(g, sprite, settings, shader.TilePalette,
+				shader.EntityPalette);
 		}
 
 		/// <summary>Unmaps the specified sprite.</summary>
-		public static UnmappedSprite UnmapSprite(Graphics2D g, ISprite sprite, SpriteSettings settings, Palette tilePalette, Palette entityPalette) {
-			UnmappedSpriteLookup lookup = new UnmappedSpriteLookup(sprite, settings, tilePalette, entityPalette);
+		public static UnmappedSprite UnmapSprite(Graphics2D g, ISprite sprite,
+			SpriteSettings settings, Palette tilePalette, Palette entityPalette)
+		{
+			UnmappedSpriteLookup lookup = new UnmappedSpriteLookup(sprite, settings,
+				tilePalette, entityPalette);
 			UnmappedSprite unmappedSprite = null;
 			if (unmappedSprites.TryGetValue(lookup, out unmappedSprite))
 				return unmappedSprite;
 
 			Rectangle2I bounds = sprite.GetBounds(settings);
 			bounds.Size = GMath.Max(Point2I.One, bounds.Size);
-			RenderTarget renderTarget = new RenderTarget(bounds.Size, SurfaceFormat.Color);
+			RenderTarget renderTarget =
+				new RenderTarget(bounds.Size, SurfaceFormat.Color);
 			GameData.SHADER_PALETTE.TilePalette = tilePalette;
 			GameData.SHADER_PALETTE.EntityPalette = entityPalette;
 			GameData.SHADER_PALETTE.ApplyParameters();

--- a/ZeldaOracle/GameOptimization/Common/Content/ContentContainer.cs
+++ b/ZeldaOracle/GameOptimization/Common/Content/ContentContainer.cs
@@ -40,6 +40,14 @@ namespace ZeldaOracle.Common.Content {
 			independentResources.Add(disposable);
 		}
 
+		/// <summary>Removes an independent resource that has been disposed of.</summary>
+		public static void RemoveDisposable(IDisposable disposable) {
+			if (!isInitialized)
+				throw new InvalidOperationException("Cannot remove disposable when " +
+					"ContentContainer has not been initialized!");
+			independentResources.Remove(disposable);
+		}
+
 
 		//-----------------------------------------------------------------------------
 		// Properties

--- a/ZeldaOracle/GameOptimization/Common/Util/XnaExtensions.cs
+++ b/ZeldaOracle/GameOptimization/Common/Util/XnaExtensions.cs
@@ -1,16 +1,17 @@
 ﻿using System.Linq;
 using Microsoft.Xna.Framework.Graphics;
+using ZeldaOracle.Common.Graphics;
 
 namespace ZeldaOracle.Common.Util {
 	/// <summary>A static class for Xna Extensions.</summary>
 	public static class XnaExtensions {
 
 		/// <summary>Gets the current render target for the graphics device.</summary>
-		public static RenderTarget2D GetRenderTarget(
+		public static RenderTarget GetRenderTarget(
 			this GraphicsDevice graphicsDevice)
 		{
-			return graphicsDevice.GetRenderTargets()
-				.LastOrDefault().RenderTarget as RenderTarget2D;
+			return RenderTarget.Wrap(graphicsDevice.GetRenderTargets()
+				.LastOrDefault().RenderTarget as RenderTarget2D);
 		}
 	}
 }


### PR DESCRIPTION
* Disposing of an image now removes it from Resources.
* Unmapping is now disposed of on Resources.Unload()
* Images and RenderTargets can now be constructed so that they are not
added to Resources and will not be disposed of on unload.
* GraphicsDevice.GetRenderTarget extension now returns wrapped
RenderTarget instead of Xna RenderTarget.
* Added Resize method to RenderTarget.